### PR TITLE
Expand file path before writing resources

### DIFF
--- a/pkg/cmd/bootstrap.go
+++ b/pkg/cmd/bootstrap.go
@@ -107,12 +107,18 @@ func (io *BootstrapParameters) Complete(name string, cmd *cobra.Command, args []
 			return err
 		}
 	} else {
+		addGitURLSuffixIfNecessary(io)
 		err := nonInteractiveMode(io, client)
 		if err != nil {
 			return err
 		}
 	}
 	return nil
+}
+
+func addGitURLSuffixIfNecessary(io *BootstrapParameters) {
+	io.GitOpsRepoURL = utility.AddGitSuffixIfNecessary(io.GitOpsRepoURL)
+	io.ServiceRepoURL = utility.AddGitSuffixIfNecessary(io.ServiceRepoURL)
 }
 
 // nonInteractiveMode gets triggered if a flag is passed, checks for mandatory flags.
@@ -186,7 +192,6 @@ func initiateInteractiveMode(io *BootstrapParameters) error {
 	io.Prefix = ui.EnterPrefix()
 	io.OutputPath = ui.EnterOutputPath()
 	io.Overwrite = true
-	log.Progressf("\nCompleting Bootstrap process\n")
 	return nil
 }
 
@@ -260,14 +265,12 @@ func (io *BootstrapParameters) Validate() error {
 	}
 
 	io.Prefix = utility.MaybeCompletePrefix(io.Prefix)
-	io.GitOpsRepoURL = utility.AddGitSuffixIfNecessary(io.GitOpsRepoURL)
-	io.ServiceRepoURL = utility.AddGitSuffixIfNecessary(io.ServiceRepoURL)
-
 	return nil
 }
 
 // Run runs the project Bootstrap command.
 func (io *BootstrapParameters) Run() error {
+	log.Progressf("\nCompleting Bootstrap process\n")
 	err := pipelines.Bootstrap(io.BootstrapOptions, ioutils.NewFilesystem())
 	if err != nil {
 		return err

--- a/pkg/cmd/bootstrap_test.go
+++ b/pkg/cmd/bootstrap_test.go
@@ -74,16 +74,13 @@ func TestAddSuffixWithBootstrap(t *testing.T) {
 
 	for _, test := range tt {
 		t.Run(test.name, func(rt *testing.T) {
-			o := BootstrapParameters{
+			o := &BootstrapParameters{
 				&pipelines.BootstrapOptions{
 					GitOpsRepoURL:  test.gitOpsURL,
 					ServiceRepoURL: test.appURL},
 			}
 
-			err := o.Validate()
-			if err != nil {
-				t.Errorf("Validate() %#v failed: ", err)
-			}
+			addGitURLSuffixIfNecessary(o)
 
 			if o.GitOpsRepoURL != test.validGitOpsURL {
 				rt.Fatalf("URL mismatch: got %s, want %s", o.GitOpsRepoURL, test.validAppURL)

--- a/pkg/pipelines/helper/error.go
+++ b/pkg/pipelines/helper/error.go
@@ -40,3 +40,11 @@ func ErrorMatch(t *testing.T, msg string, testErr error) bool {
 	}
 	return match
 }
+
+// AssertNoError fails if there's an error
+func AssertNoError(t *testing.T, err error) {
+	t.Helper()
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/pkg/pipelines/yaml/resources.go
+++ b/pkg/pipelines/yaml/resources.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"path/filepath"
 
+	"github.com/mitchellh/go-homedir"
 	"github.com/spf13/afero"
 	"sigs.k8s.io/yaml"
 )
@@ -15,6 +16,10 @@ import (
 //
 // It returns the list of filenames written out.
 func WriteResources(fs afero.Fs, path string, files map[string]interface{}) ([]string, error) {
+	path, err := homedir.Expand(path)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to resolve path to file: %v", err)
+	}
 	filenames := make([]string, 0)
 	for filename, item := range files {
 		err := MarshalItemToFile(fs, filepath.Join(path, filename), item)

--- a/pkg/pipelines/yaml/resources_test.go
+++ b/pkg/pipelines/yaml/resources_test.go
@@ -1,0 +1,56 @@
+package yaml
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/redhat-developer/kam/pkg/pipelines/namespaces"
+	res "github.com/redhat-developer/kam/pkg/pipelines/resources"
+	"github.com/spf13/afero"
+	"sigs.k8s.io/yaml"
+)
+
+func TestWriteResources(t *testing.T) {
+	fs := afero.NewOsFs()
+	homeEnv := "HOME"
+	originalHome := os.Getenv(homeEnv)
+	defer os.Setenv(homeEnv, originalHome)
+	path, cleanup := makeTempDir(t)
+	defer cleanup()
+	os.Setenv("HOME", path)
+	sampleYAML := namespaces.Create("test", "https://github.com/org/test")
+	r := res.Resources{
+		"test/myfile.yaml": sampleYAML,
+	}
+
+	_, err := WriteResources(fs, "~/manifest", r)
+	assertNoError(t, err)
+
+	want, err := yaml.Marshal(sampleYAML)
+	assertNoError(t, err)
+	got, err := ioutil.ReadFile(filepath.Join(path, "manifest/test/myfile.yaml"))
+	assertNoError(t, err)
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Fatalf("files not written to correct location: %s", diff)
+	}
+}
+
+func makeTempDir(t *testing.T) (string, func()) {
+	t.Helper()
+	dir, err := ioutil.TempDir(os.TempDir(), "manifest")
+	assertNoError(t, err)
+	return dir, func() {
+		err := os.RemoveAll(dir)
+		assertNoError(t, err)
+	}
+}
+
+func assertNoError(t *testing.T, err error) {
+	t.Helper()
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/pkg/pipelines/yaml/resources_test.go
+++ b/pkg/pipelines/yaml/resources_test.go
@@ -4,9 +4,11 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/redhat-developer/kam/pkg/pipelines/helper"
 	"github.com/redhat-developer/kam/pkg/pipelines/namespaces"
 	res "github.com/redhat-developer/kam/pkg/pipelines/resources"
 	"github.com/spf13/afero"
@@ -20,37 +22,55 @@ func TestWriteResources(t *testing.T) {
 	defer os.Setenv(homeEnv, originalHome)
 	path, cleanup := makeTempDir(t)
 	defer cleanup()
-	os.Setenv("HOME", path)
+	os.Setenv(homeEnv, path)
 	sampleYAML := namespaces.Create("test", "https://github.com/org/test")
 	r := res.Resources{
 		"test/myfile.yaml": sampleYAML,
 	}
 
-	_, err := WriteResources(fs, "~/manifest", r)
-	assertNoError(t, err)
+	tests := []struct {
+		name   string
+		path   string
+		errMsg string
+	}{
+		{"Path with ~", "~/manifest", ""},
+		{"Path without ~", filepath.Join(path, "manifest/gitops"), ""},
+		{"Path without permission", "/", "failed to MkDirAll for /test/myfile.yaml: mkdir /test: permission denied"},
+	}
 
-	want, err := yaml.Marshal(sampleYAML)
-	assertNoError(t, err)
-	got, err := ioutil.ReadFile(filepath.Join(path, "manifest/test/myfile.yaml"))
-	assertNoError(t, err)
-	if diff := cmp.Diff(want, got); diff != "" {
-		t.Fatalf("files not written to correct location: %s", diff)
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := WriteResources(fs, test.path, r)
+			if !helper.ErrorMatch(t, test.errMsg, err) {
+				t.Fatalf("error mismatch: got %v, want %v", err, test.errMsg)
+			}
+			if test.path[0] == '~' {
+				test.path = filepath.Join(path, strings.Split(test.path, "~")[1])
+			}
+			if err == nil {
+				assertResourceExists(t, filepath.Join(test.path, "test/myfile.yaml"), sampleYAML)
+			}
+		})
 	}
 }
 
 func makeTempDir(t *testing.T) (string, func()) {
 	t.Helper()
 	dir, err := ioutil.TempDir(os.TempDir(), "manifest")
-	assertNoError(t, err)
+	helper.AssertNoError(t, err)
 	return dir, func() {
 		err := os.RemoveAll(dir)
-		assertNoError(t, err)
+		helper.AssertNoError(t, err)
 	}
 }
 
-func assertNoError(t *testing.T, err error) {
+func assertResourceExists(t *testing.T, path string, resource interface{}) {
 	t.Helper()
-	if err != nil {
-		t.Fatal(err)
+	want, err := yaml.Marshal(resource)
+	helper.AssertNoError(t, err)
+	got, err := ioutil.ReadFile(path)
+	helper.AssertNoError(t, err)
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Fatalf("files not written to correct location: %s", diff)
 	}
 }


### PR DESCRIPTION
**What type of PR is this?**
> /kind bug

**What does this PR do / why we need it**:
* The interactive prompt can now accept relative path and tilde(`~`)
* Add .git suffix before checking dependencies
* Move the completion message to Run(), to keep the UX similar in both the modes

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:
