### PR TITLE
Uploading kam bits to prow artifacts

### DIFF
--- a/scripts/openshiftci-presubmit-unittests.sh
+++ b/scripts/openshiftci-presubmit-unittests.sh
@@ -21,10 +21,7 @@ make test
 
 # crosscompile and publish artifacts
 make all_platforms
-pwd
-ls -l
-ls -l $GOPATH/src/github.com/redhat-developer/kam
-#cp $GOPATH/src/github.com/redhat-developer/kam/kam_linux_amd64.exe $ARTIFACTS_DIR
-#cp $GOPATH/src/github.com/redhat-developer/kam/kam_darwin_amd64.exe $ARTIFACTS_DIR
-#cp $GOPATH/src/github.com/redhat-developer/kam/kam_windows_amd64.exe $ARTIFACTS_DIR
 
+cp kam_darwin_amd64 $CUSTOM_HOMEDIR
+cp kam_linux_amd64 $CUSTOM_HOMEDIR
+cp kam_windows_amd64.exe $CUSTOM_HOMEDIR


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind` line, and delete the rest.
> For example, `> /kind bug` would simply become: `/kind bug`

/kind feature

**What does this PR do / why we need it**:
All platform bits should be available in prow artifacts directory for each pr

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #38

**How to test changes / Special notes to the reviewer**:

Bits should be available here at - https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/pr-logs/pull/redhat-developer_kam/39/pull-ci-redhat-developer-kam-master-unit/1310893860162899968/artifacts/unit/
