### PR TITLE
Strip remaining references to odo from the code.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -39,7 +39,6 @@ replace (
 	github.com/docker/docker => github.com/docker/docker v17.12.0-ce-rc1.0.20200309214505-aa6a9891b09c+incompatible
 	github.com/h2non/gock => gopkg.in/h2non/gock.v1 v1.0.14
 	github.com/openshift/api => github.com/openshift/api v0.0.0-20200205133042-34f0ec8dab87
-	github.com/openshift/odo => github.com/openshift/odo v1.2.6
 	k8s.io/api => k8s.io/api v0.17.1
 	k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.17.1
 	k8s.io/apimachinery => github.com/openshift/kubernetes-apimachinery v0.0.0-20191211181342-5a804e65bdc1

--- a/pkg/cmd/bootstrap.go
+++ b/pkg/cmd/bootstrap.go
@@ -61,7 +61,7 @@ var (
 	bootstrapShortDesc = `Bootstrap pipelines with a starter configuration`
 )
 
-// BootstrapParameters encapsulates the parameters for the odo pipelines init command.
+// BootstrapParameters encapsulates the parameters for the kam pipelines init command.
 type BootstrapParameters struct {
 	*pipelines.BootstrapOptions
 }

--- a/pkg/cmd/build.go
+++ b/pkg/cmd/build.go
@@ -27,7 +27,7 @@ var (
 	buildShortDesc = `Build pipelines files`
 )
 
-// BuildParameters encapsulates the parameters for the odo pipelines build command.
+// BuildParameters encapsulates the parameters for the kam pipelines build command.
 type BuildParameters struct {
 	pipelinesFolderPath string
 	output              string // path to add Gitops resources

--- a/pkg/cmd/environment/add.go
+++ b/pkg/cmd/environment/add.go
@@ -27,7 +27,7 @@ var (
 	addEnvShortDesc = `Add a new environment`
 )
 
-// AddEnvParameters encapsulates the parameters for the odo pipelines init command.
+// AddEnvParameters encapsulates the parameters for the kam pipelines init command.
 type AddEnvParameters struct {
 	envName         string
 	pipelinesFolder string

--- a/pkg/cmd/environment/add_test.go
+++ b/pkg/cmd/environment/add_test.go
@@ -24,7 +24,7 @@ func TestAddCommandWithMissingParams(t *testing.T) {
 	}
 	for _, tt := range cmdTests {
 		t.Run(tt.desc, func(rt *testing.T) {
-			_, _, err := executeCommand(NewCmdAddEnv("add", "odo pipelines environment"), tt.flags...)
+			_, _, err := executeCommand(NewCmdAddEnv("add", "kam pipelines environment"), tt.flags...)
 			if err.Error() != tt.wantErr {
 				rt.Errorf("got %s, want %s", err, tt.wantErr)
 			}

--- a/pkg/cmd/service/add_test.go
+++ b/pkg/cmd/service/add_test.go
@@ -60,7 +60,7 @@ func TestAddCommandWithMissingParams(t *testing.T) {
 	}
 	for _, tt := range cmdTests {
 		t.Run(tt.desc, func(t *testing.T) {
-			_, _, err := executeCommand(newCmdAdd("add", "odo pipelines service"), tt.flags...)
+			_, _, err := executeCommand(newCmdAdd("add", "kam pipelines service"), tt.flags...)
 			if err.Error() != tt.wantErr {
 				t.Errorf("got %s, want %s", err, tt.wantErr)
 			}

--- a/pkg/cmd/service/service.go
+++ b/pkg/cmd/service/service.go
@@ -29,6 +29,5 @@ func NewCmd(name, fullName string) *cobra.Command {
 	cmd.AddCommand(addCmd)
 
 	cmd.Annotations = map[string]string{"command": "main"}
-	// cmd.SetUsageTemplate(odoutil.CmdUsageTemplate)
 	return cmd
 }

--- a/pkg/cmd/webhook/create.go
+++ b/pkg/cmd/webhook/create.go
@@ -25,7 +25,7 @@ type createOptions struct {
 	options
 }
 
-// Run contains the logic for the odo command
+// Run contains the logic for the kam command
 func (o *createOptions) Run() error {
 	id, err := backend.Create(o.accessToken, o.pipelinesFolderPath, o.getAppServiceNames(), o.isCICD)
 

--- a/pkg/cmd/webhook/create_test.go
+++ b/pkg/cmd/webhook/create_test.go
@@ -25,7 +25,7 @@ func TestMissingRequiredFlagsForCreate(t *testing.T) {
 	}
 	for i, tt := range testcases {
 		t.Run(fmt.Sprintf("Test %d", i), func(rt *testing.T) {
-			_, err := executeCommand(newCmdCreate("webhook", "odo pipelines webhook create"), tt.flags...)
+			_, err := executeCommand(newCmdCreate("webhook", "kam pipelines webhook create"), tt.flags...)
 
 			if err != nil {
 				if err.Error() != tt.wantErr {

--- a/pkg/cmd/webhook/delete.go
+++ b/pkg/cmd/webhook/delete.go
@@ -24,9 +24,8 @@ type deleteOptions struct {
 	options
 }
 
-// Run contains the logic for the odo command
+// Run contains the logic for the kam command
 func (o *deleteOptions) Run() error {
-
 	ids, err := backend.Delete(o.accessToken, o.pipelinesFolderPath, o.getAppServiceNames(), o.isCICD)
 
 	if len(ids) > 0 {

--- a/pkg/cmd/webhook/delete_test.go
+++ b/pkg/cmd/webhook/delete_test.go
@@ -6,7 +6,6 @@ import (
 )
 
 func TestMissingRequiredFlagsForDelete(t *testing.T) {
-
 	testcases := []struct {
 		flags   []keyValuePair
 		wantErr string
@@ -18,7 +17,7 @@ func TestMissingRequiredFlagsForDelete(t *testing.T) {
 
 	for i, tt := range testcases {
 		t.Run(fmt.Sprintf("Test %d", i), func(rt *testing.T) {
-			_, err := executeCommand(newCmdDelete("webhook", "odo pipelines webhook delete"), tt.flags...)
+			_, err := executeCommand(newCmdDelete("webhook", "kam pipelines webhook delete"), tt.flags...)
 
 			if err != nil {
 				if err.Error() != tt.wantErr {

--- a/pkg/cmd/webhook/list.go
+++ b/pkg/cmd/webhook/list.go
@@ -24,9 +24,8 @@ type listOptions struct {
 	options
 }
 
-// Run contains the logic for the odo command
+// Run contains the logic for the kam command
 func (o *listOptions) Run() error {
-
 	ids, err := backend.List(o.accessToken, o.pipelinesFolderPath, o.getAppServiceNames(), o.isCICD)
 	if err != nil {
 		return fmt.Errorf("Unable to a get list of webhook IDs: %v", err)

--- a/pkg/cmd/webhook/list_test.go
+++ b/pkg/cmd/webhook/list_test.go
@@ -17,7 +17,7 @@ func TestMissingRequiredFlagsForList(t *testing.T) {
 
 	for i, tt := range testcases {
 		t.Run(fmt.Sprintf("Test %d", i), func(rt *testing.T) {
-			_, err := executeCommand(newCmdList("webhook", "odo pipelines webhook create"), tt.flags...)
+			_, err := executeCommand(newCmdList("webhook", "kam pipelines webhook create"), tt.flags...)
 
 			if err != nil {
 				if err.Error() != tt.wantErr {

--- a/pkg/pipelines/argocd/argocd.go
+++ b/pkg/pipelines/argocd/argocd.go
@@ -5,7 +5,7 @@ import (
 	"sort"
 
 	// This is a hack because ArgoCD doesn't support a compatible (code-wise)
-	// version of k8s in common with odo.
+	// version of k8s in common with kam.
 
 	argov1 "github.com/redhat-developer/kam/pkg/pipelines/argocd/operator/v1alpha1"
 	argoappv1 "github.com/redhat-developer/kam/pkg/pipelines/argocd/v1alpha1"

--- a/pkg/pipelines/argocd/argocd_test.go
+++ b/pkg/pipelines/argocd/argocd_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/redhat-developer/kam/pkg/pipelines/meta"
 
 	// This is a hack because ArgoCD doesn't support a compatible (code-wise)
-	// version of k8s in common with odo.
+	// version of k8s in common with kam
 	argov1 "github.com/redhat-developer/kam/pkg/pipelines/argocd/operator/v1alpha1"
 	argoappv1 "github.com/redhat-developer/kam/pkg/pipelines/argocd/v1alpha1"
 	res "github.com/redhat-developer/kam/pkg/pipelines/resources"


### PR DESCRIPTION
**What type of PR is this?**
> /kind cleanup
**What does this PR do / why we need it**:

Removes all the removable references to `odo` from the source.

There are references to the sole import from odo in our source-tree.

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:
