### PR TITLE
 The check for access token completed on the UI front

### DIFF
--- a/pkg/cmd/bootstrap.go
+++ b/pkg/cmd/bootstrap.go
@@ -190,6 +190,8 @@ func initiateInteractiveMode(io *BootstrapParameters) error {
 		if io.GitHostAccessToken == "" {
 			io.GitHostAccessToken = ui.EnterGitHostAccessToken(io.ServiceRepoURL)
 		}
+	} else {
+		io.CommitStatusTracker = false
 	}
 	io.Prefix = ui.EnterPrefix()
 	io.OutputPath = ui.EnterOutputPath()


### PR DESCRIPTION
**What type of PR is this?**
> /kind bug

**What does this PR do / why we need it**:

Git-host access token requires that the commit-status-tracker to be true, however on the UI side we get an error if the commit-status-tracker option is no. Hence the fix.
