### PR TITLE
kam service add creates a new config directory.

### DIFF
--- a/docs/journey/day2/README.md
+++ b/docs/journey/day2/README.md
@@ -80,7 +80,7 @@ In the Application's folder, a kustomization.yaml is generated to reference the 
 
 * `environments/new-env/apps/app-bus/services/bus/base/kustomization.yaml`
 
-In the Service's base folder, an empty `config` folder is created.   (Please create `config` if it does not exist.)  This is the folder you will add `deployment yaml` files to specify how the Service should be deployed.
+In the Service's base folder, an empty `config` folder is created. This is the folder in which you will add `deployment yaml` files to specify how the Service should be deployed.
 
 * `environments/new-env/apps/app-bus/services/bus/base/config`
 

--- a/pkg/pipelines/environment_test.go
+++ b/pkg/pipelines/environment_test.go
@@ -35,7 +35,10 @@ func TestAddEnv(t *testing.T) {
 	}
 	for _, path := range wantedPaths {
 		t.Run(fmt.Sprintf("checking path %s already exists", path), func(rt *testing.T) {
-			assertFileExists(rt, fakeFs, filepath.Join(gitopsPath, path))
+			exists, _ := fakeFs.Exists(filepath.Join(gitopsPath, path))
+			if !exists {
+				t.Fatalf("The file is not present at path : %v", path)
+			}
 		})
 	}
 
@@ -74,7 +77,11 @@ func TestAddEnvWithClusterProvided(t *testing.T) {
 	}
 	for _, path := range wantedPaths {
 		t.Run(fmt.Sprintf("checking path %s already exists", path), func(rt *testing.T) {
-			assertFileExists(rt, fakeFs, filepath.Join(gitopsPath, path))
+			exists, _ := fakeFs.Exists(filepath.Join(gitopsPath, path))
+			if !exists {
+				t.Fatalf("The file is not present at path : %v", path)
+			}
+
 		})
 	}
 
@@ -220,34 +227,6 @@ func assertNoError(t *testing.T, err error) {
 	t.Helper()
 	if err != nil {
 		t.Fatal(err)
-	}
-}
-
-func assertFileExists(t *testing.T, testFs afero.Fs, path string) {
-	t.Helper()
-	exists, err := afero.Exists(testFs, path)
-	assertNoError(t, err)
-	if !exists {
-		t.Fatalf("unable to find file %q", path)
-	}
-	isDir, err := afero.DirExists(testFs, path)
-	assertNoError(t, err)
-	if isDir {
-		t.Fatalf("%q is a directory", path)
-	}
-}
-
-func assertDirExists(t *testing.T, testFs afero.Fs, path string) {
-	t.Helper()
-	exists, err := afero.Exists(testFs, path)
-	assertNoError(t, err)
-	if !exists {
-		t.Fatalf("unable to find directory %q", path)
-	}
-	isDir, err := afero.DirExists(testFs, path)
-	assertNoError(t, err)
-	if !isDir {
-		t.Fatalf("%q is not a directory", path)
 	}
 }
 

--- a/pkg/pipelines/environment_test.go
+++ b/pkg/pipelines/environment_test.go
@@ -35,6 +35,7 @@ func TestAddEnv(t *testing.T) {
 	}
 	for _, path := range wantedPaths {
 		t.Run(fmt.Sprintf("checking path %s already exists", path), func(rt *testing.T) {
+			// The inmemory version of Afero doesn't return errors
 			exists, _ := fakeFs.Exists(filepath.Join(gitopsPath, path))
 			if !exists {
 				t.Fatalf("The file is not present at path : %v", path)
@@ -77,6 +78,7 @@ func TestAddEnvWithClusterProvided(t *testing.T) {
 	}
 	for _, path := range wantedPaths {
 		t.Run(fmt.Sprintf("checking path %s already exists", path), func(rt *testing.T) {
+			// The inmemory version of Afero doesn't return errors
 			exists, _ := fakeFs.Exists(filepath.Join(gitopsPath, path))
 			if !exists {
 				t.Fatalf("The file is not present at path : %v", path)

--- a/pkg/pipelines/environment_test.go
+++ b/pkg/pipelines/environment_test.go
@@ -237,6 +237,20 @@ func assertFileExists(t *testing.T, testFs afero.Fs, path string) {
 	}
 }
 
+func assertDirExists(t *testing.T, testFs afero.Fs, path string) {
+	t.Helper()
+	exists, err := afero.Exists(testFs, path)
+	assertNoError(t, err)
+	if !exists {
+		t.Fatalf("unable to find directory %q", path)
+	}
+	isDir, err := afero.DirExists(testFs, path)
+	assertNoError(t, err)
+	if !isDir {
+		t.Fatalf("%q is not a directory", path)
+	}
+}
+
 func mustReadFileAsMap(t *testing.T, fs afero.Fs, filename string) map[string]interface{} {
 	t.Helper()
 	b, err := afero.ReadFile(fs, filename)

--- a/pkg/pipelines/ioutils/file_utils.go
+++ b/pkg/pipelines/ioutils/file_utils.go
@@ -8,13 +8,13 @@ import (
 )
 
 // NewFilesystem returns a local filesystem based afero FS implementation.
-func NewFilesystem() afero.Fs {
-	return afero.NewOsFs()
+func NewFilesystem() afero.Afero {
+	return afero.Afero{Fs: afero.NewOsFs()}
 }
 
 // NewMemoryFilesystem returns an in-memory afero FS implementation.
-func NewMemoryFilesystem() afero.Fs {
-	return afero.NewMemMapFs()
+func NewMemoryFilesystem() afero.Afero {
+	return afero.Afero{Fs: afero.NewMemMapFs()}
 }
 
 // IsExisting returns bool whether path exists

--- a/pkg/pipelines/service.go
+++ b/pkg/pipelines/service.go
@@ -204,7 +204,7 @@ func createSvcImageBinding(cfg *config.PipelinesConfig, env *config.Environment,
 func createConfigFolder(m *config.Manifest, appFs afero.Fs, o *AddServiceOptions) error {
 	basePath, err := homedir.Expand(o.PipelinesFolderPath)
 	if err != nil {
-		return err
+		return fmt.Errorf("Cannot expand the pipelines.yaml path : %s", o.PipelinesFolderPath)
 	}
 	env := m.GetEnvironment(o.EnvName)
 	app := m.GetApplication(o.EnvName, o.AppName)

--- a/pkg/pipelines/service_test.go
+++ b/pkg/pipelines/service_test.go
@@ -294,7 +294,10 @@ func TestAddServiceFilePaths(t *testing.T) {
 	assertNoError(t, err)
 	for _, path := range wantedPaths {
 		t.Run(fmt.Sprintf("checking path %s already exists", path), func(rt *testing.T) {
-			assertFileExists(rt, fakeFs, filepath.Join(outputPath, path))
+			exists, _ := fakeFs.Exists(filepath.Join(outputPath, path))
+			if !exists {
+				t.Fatalf("The file is not present at : %v", path)
+			}
 		})
 	}
 }
@@ -324,7 +327,10 @@ func TestAddServiceFolderPaths(t *testing.T) {
 	assertNoError(t, err)
 	for _, path := range wantedPaths {
 		t.Run(fmt.Sprintf("checking path %s already exists", path), func(rt *testing.T) {
-			assertDirExists(rt, fakeFs, filepath.Join(outputPath, path))
+			exists, _ := fakeFs.DirExists(filepath.Join(outputPath, path))
+			if !exists {
+				t.Fatalf("The directory does not exist at path : %v", path)
+			}
 		})
 	}
 }

--- a/pkg/pipelines/service_test.go
+++ b/pkg/pipelines/service_test.go
@@ -294,6 +294,7 @@ func TestAddServiceFilePaths(t *testing.T) {
 	assertNoError(t, err)
 	for _, path := range wantedPaths {
 		t.Run(fmt.Sprintf("checking path %s already exists", path), func(rt *testing.T) {
+			// The inmemory version of Afero doesn't return errors
 			exists, _ := fakeFs.Exists(filepath.Join(outputPath, path))
 			if !exists {
 				t.Fatalf("The file is not present at : %v", path)
@@ -327,6 +328,7 @@ func TestAddServiceFolderPaths(t *testing.T) {
 	assertNoError(t, err)
 	for _, path := range wantedPaths {
 		t.Run(fmt.Sprintf("checking path %s already exists", path), func(rt *testing.T) {
+			// The inmemory version of Afero doesn't return errors
 			exists, _ := fakeFs.DirExists(filepath.Join(outputPath, path))
 			if !exists {
 				t.Fatalf("The directory does not exist at path : %v", path)


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What does this PR do / why we need it**:
The `kam service add` command does not create the `config` folder in the base directory. This fix corrects that error.

**Have you updated the necessary documentation?**

* [x] Documentation update is required by this PR.
* [x] Documentation has been updated.

**Which issue(s) this PR fixes**:
https://issues.redhat.com/browse/GITOPS-360

**How to test changes / Special notes to the reviewer**:

