### PR TITLE
Installing github cli in test container

### DIFF
--- a/openshift-ci/build-root/Dockerfile
+++ b/openshift-ci/build-root/Dockerfile
@@ -2,4 +2,10 @@
 
 FROM registry.svc.ci.openshift.org/openshift/release:golang-1.14
 
-RUN yum -y install httpd-tools
+RUN yum -y install dnf httpd-tools
+
+RUN dnf -y install 'dnf-command(config-manager)'
+
+RUN dnf -y config-manager --add-repo https://cli.github.com/packages/rpm/gh-cli.repo
+
+RUN dnf -y install gh


### PR DESCRIPTION
**What type of PR is this?**
/kind enhancement

**What does this PR do / why we need it**:
As per the doc https://github.com/redhat-developer/kam/blob/master/docs/journey/day1/prerequisites/gitops_repo.md we need to install the [github cli](https://github.com/cli/cli) in the test container to create a fresh github repo which will be used for Bootstrapping the Manifest input for each pr

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR - Documentation will be covered in - https://github.com/redhat-developer/kam/pull/54
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes NA

**How to test changes / Special notes to the reviewer**:

- Build the docker file https://github.com/redhat-developer/kam/compare/master...amitkrout:installingGithubCliInTestContainer?expand=1#diff-01f4ec918b634e024905add2f91a58ab
- Run it ```docker run -it <image_id>```
- In the container execute ```gh version```. It should display the github cli version

