### PR TITLE
Fixing doc generate failure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ openshiftci-presubmit-unittests:
 
 .PHONY: cmd-docs
 cmd-docs:
-	go run tools/cmd-docs/main.go
+	go run -mod=readonly tools/cmd-docs/main.go
 
 .PHONY: prepare-test-cluster
 prepare-test-cluster:

--- a/docs/commands/kam_service.md
+++ b/docs/commands/kam_service.md
@@ -22,17 +22,17 @@ add
 ### Options
 
 ```
-      --app-name string                                Name of the application where the service will be added
-      --env-name string                                Name of the environment where the service will be added
-      --git-repo-url string                            GitOps repository e.g. https://github.com/organisation/repository
-  -h, --help                                           help for service
-      --image-repo string                              Image repository of the form <registry>/<username>/<repository> or <project>/<app> which is used to push newly built images
-      --image-repo-internal-registry-hostname string   Host-name for internal image registry e.g. docker-registry.default.svc.cluster.local:5000, used if you are pushing your images to the internal image registry (default "image-registry.openshift-image-registry.svc:5000")
-      --pipelines-folder string                        Folder path to retrieve manifest, eg. /test where manifest exists at /test/pipelines.yaml (default ".")
-      --sealed-secrets-ns string                       Namespace in which the Sealed Secrets operator is installed, automatically generated secrets are encrypted with this operator (default "cicd")
-      --sealed-secrets-svc string                      Name of the Sealed Secrets services that encrypts secrets (default "sealedsecretcontroller-sealed-secrets")
-      --service-name string                            Name of the service to be added
-      --webhook-secret string                          Source Git repository webhook secret (if not provided, it will be auto-generated)
+      --app-name string                                    Name of the application where the service will be added
+      --env-name string                                    Name of the environment where the service will be added
+      --git-repo-url string                                GitOps repository e.g. https://github.com/organisation/repository
+  -h, --help                                               help for service
+      --image-registry-internal-registry-hostname string   Host-name for internal image registry e.g. docker-registry.default.svc.cluster.local:5000, used if you are pushing your images to the internal image registry (default "image-registry.openshift-image-registry.svc:5000")
+      --image-repo string                                  Image registry of the form <registry>/<username>/<image name> or <project>/<app> which is used to push newly built images
+      --pipelines-folder string                            Folder path to retrieve manifest, eg. /test where manifest exists at /test/pipelines.yaml (default ".")
+      --sealed-secrets-ns string                           Namespace in which the Sealed Secrets operator is installed, automatically generated secrets are encrypted with this operator (default "cicd")
+      --sealed-secrets-svc string                          Name of the Sealed Secrets services that encrypts secrets (default "sealedsecretcontroller-sealed-secrets")
+      --service-name string                                Name of the service to be added
+      --webhook-secret string                              Source Git repository webhook secret (if not provided, it will be auto-generated)
 ```
 
 ### SEE ALSO

--- a/docs/commands/kam_service_add.md
+++ b/docs/commands/kam_service_add.md
@@ -20,17 +20,17 @@ kam service add [flags]
 ### Options
 
 ```
-      --app-name string                                Name of the application where the service will be added
-      --env-name string                                Name of the environment where the service will be added
-      --git-repo-url string                            GitOps repository e.g. https://github.com/organisation/repository
-  -h, --help                                           help for add
-      --image-repo string                              Image repository of the form <registry>/<username>/<repository> or <project>/<app> which is used to push newly built images
-      --image-repo-internal-registry-hostname string   Host-name for internal image registry e.g. docker-registry.default.svc.cluster.local:5000, used if you are pushing your images to the internal image registry (default "image-registry.openshift-image-registry.svc:5000")
-      --pipelines-folder string                        Folder path to retrieve manifest, eg. /test where manifest exists at /test/pipelines.yaml (default ".")
-      --sealed-secrets-ns string                       Namespace in which the Sealed Secrets operator is installed, automatically generated secrets are encrypted with this operator (default "cicd")
-      --sealed-secrets-svc string                      Name of the Sealed Secrets services that encrypts secrets (default "sealedsecretcontroller-sealed-secrets")
-      --service-name string                            Name of the service to be added
-      --webhook-secret string                          Source Git repository webhook secret (if not provided, it will be auto-generated)
+      --app-name string                                    Name of the application where the service will be added
+      --env-name string                                    Name of the environment where the service will be added
+      --git-repo-url string                                GitOps repository e.g. https://github.com/organisation/repository
+  -h, --help                                               help for add
+      --image-registry-internal-registry-hostname string   Host-name for internal image registry e.g. docker-registry.default.svc.cluster.local:5000, used if you are pushing your images to the internal image registry (default "image-registry.openshift-image-registry.svc:5000")
+      --image-repo string                                  Image registry of the form <registry>/<username>/<image name> or <project>/<app> which is used to push newly built images
+      --pipelines-folder string                            Folder path to retrieve manifest, eg. /test where manifest exists at /test/pipelines.yaml (default ".")
+      --sealed-secrets-ns string                           Namespace in which the Sealed Secrets operator is installed, automatically generated secrets are encrypted with this operator (default "cicd")
+      --sealed-secrets-svc string                          Name of the Sealed Secrets services that encrypts secrets (default "sealedsecretcontroller-sealed-secrets")
+      --service-name string                                Name of the service to be added
+      --webhook-secret string                              Source Git repository webhook secret (if not provided, it will be auto-generated)
 ```
 
 ### SEE ALSO

--- a/scripts/openshiftci-presubmit-unittests.sh
+++ b/scripts/openshiftci-presubmit-unittests.sh
@@ -26,8 +26,6 @@ else
     echo "command-documentation is up-to-date."
 fi
 
-make bin
-
 # crosscompile and publish artifacts
 make all_platforms
 

--- a/scripts/openshiftci-presubmit-unittests.sh
+++ b/scripts/openshiftci-presubmit-unittests.sh
@@ -18,6 +18,14 @@ go env
 make gomod_tidy
 make bin
 make test
+make cmd-docs
+if [[ ! -z $(git status -s) ]]
+then
+    echo "command-documentation is out of date (run make cmd-docs)."
+    exit 1
+else
+    echo "command-documentation is up-to-date."
+fi
 
 # crosscompile and publish artifacts
 make all_platforms

--- a/scripts/openshiftci-presubmit-unittests.sh
+++ b/scripts/openshiftci-presubmit-unittests.sh
@@ -16,7 +16,6 @@ git describe --always --long --dirty
 go version
 go env
 make gomod_tidy
-make bin
 make test
 make cmd-docs
 if [[ ! -z $(git status -s) ]]
@@ -26,6 +25,8 @@ then
 else
     echo "command-documentation is up-to-date."
 fi
+
+make bin
 
 # crosscompile and publish artifacts
 make all_platforms


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind` line, and delete the rest.
> For example, `> /kind bug` would simply become: `/kind bug`

/kind failing-test
/kind enhancement

**What does this PR do / why we need it**:
Prow unable to sense github action failure. So to avoid merges after failure, i have added the `make docs` in the prow job so that the failure status will be identified and pr won't merge into the master. 

<img width="941" alt="Screen Shot 2020-10-20 at 8 13 33 PM" src="https://user-images.githubusercontent.com/19851115/96602975-35a04600-1311-11eb-9ee3-87fc9eae1dd7.png">


**Have you updated the necessary documentation?**

* [x] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes NA

**How to test changes / Special notes to the reviewer**:
`make docs` error should be reported in prow job 