### PR TITLE
Create developer login session in CI

### DIFF
--- a/scripts/openshiftci-presubmit-all-tests.sh
+++ b/scripts/openshiftci-presubmit-all-tests.sh
@@ -16,4 +16,24 @@ export PATH="$PATH:$(pwd)/bin"
 export ARTIFACTS_DIR="/tmp/artifacts"
 export CUSTOM_HOMEDIR=$ARTIFACTS_DIR
 
+# Copy kubeconfig to temporary kubeconfig file and grant
+# read and Write permission to temporary kubeconfig file
+TMP_DIR=$(mktemp -d)
+cp $KUBECONFIG $TMP_DIR/kubeconfig
+chmod 640 $TMP_DIR/kubeconfig
+export KUBECONFIG=$TMP_DIR/kubeconfig
+
+# Login as developer
+oc login -u developer -p developer
+
+# Check login user name for debugging purpose
+oc whoami
+login_user=`oc whoami`
+if [[ $login_user == *"developer"* ]]; then
+    echo "Login to the cluster as a developer user"
+else
+    echo "Fail to login as a developer user"
+    exit 1
+fi
+
 kam version


### PR DESCRIPTION
**What type of PR is this?**
/kind enhancement

**What does this PR do / why we need it**:
Providing a developer login session to run the following operations 

kam CLI bootstraps and generates CI/CD pipelines with starter app, push to gitops repository, oc apply -f /config/argocd (i.e. create argocd apps in the generated config) etc...

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes NA

**How to test changes / Special notes to the reviewer**:

```
+ oc login -u developer -p developer
Login successful.

You have access to the following projects and can switch between them with 'oc project <projectname>':

  * argocd
    cicd

Using project "argocd".
+ oc whoami
developer
```

Check the prow log - https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/pr-logs/pull/redhat-developer_kam/68/pull-ci-redhat-developer-kam-master-v4.5-integration-e2e/1318884090304270336/artifacts/integration-e2e/integration-e2e-steps/container-logs/test.log
