### PR TITLE
output built binaries in  "dist" folder

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps 
-          asset_path: ./kam_linux_amd64
+          asset_path: ./dist/kam_linux_amd64
           asset_name: kam_linux_amd64
           asset_content_type: application/octet-stream
       - name: Upload kam_windows_amd64.exe
@@ -43,7 +43,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps 
-          asset_path: ./kam_windows_amd64.exe
+          asset_path: ./dist//kam_windows_amd64.exe
           asset_name: kam_windows_amd64.exe
           asset_content_type: application/octet-stream          
       - name: Upload kam_darwin_amd64
@@ -53,6 +53,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps 
-          asset_path: ./kam_darwin_amd64
+          asset_path: ./dist/kam_darwin_amd64
           asset_name: kam_darwin_amd64
           asset_content_type: application/octet-stream             

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps 
-          asset_path: ./dist//kam_windows_amd64.exe
+          asset_path: ./dist/kam_windows_amd64.exe
           asset_name: kam_windows_amd64.exe
           asset_content_type: application/octet-stream          
       - name: Upload kam_darwin_amd64

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@
 
 # Ignore binary
 dist/
+bin/

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,3 @@
 
 # Ignore binary
 dist/
-kam_windows_amd64.exe
-kam_linux_amd64
-kam_darwin_amd64

--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,7 @@
 # vendor/
 
 # Ignore binary
-./kam
+dist/
 kam_windows_amd64.exe
 kam_linux_amd64
 kam_darwin_amd64

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,6 @@
 
+
+BIN_DIR=bin
 DIST_DIR=dist
 EXECUTABLE=kam
 WINDOWS=$(EXECUTABLE)_windows_amd64.exe
@@ -44,7 +46,7 @@ gofmt:
 
 .PHONY: bin
 bin:
-	go build  ${CFLAGS} -o $(DIST_DIR)/$(EXECUTABLE) -ldflags=$(LD_FLAGS) cmd/kam/kam.go 
+	go build  ${CFLAGS} -o $(BIN_DIR)/$(EXECUTABLE) -ldflags=$(LD_FLAGS) cmd/kam/kam.go 
 
 .PHONY: install
 install:
@@ -56,7 +58,7 @@ test:
 
 .PHONY: clean
 clean:
-	@rm -f $(DIST_DIR)/*
+	@rm -f $(DIST_DIR)/* $(BIN_DIR)/*
 	
 .PHONY: openshiftci-presubmit-unittests
 openshiftci-presubmit-unittests:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 
+DIST_DIR=dist
 EXECUTABLE=kam
 WINDOWS=$(EXECUTABLE)_windows_amd64.exe
 LINUX=$(EXECUTABLE)_linux_amd64
@@ -20,13 +21,13 @@ linux: $(LINUX)
 darwin: $(DARWIN) 
 
 $(WINDOWS):
-	env GOOS=windows GOARCH=amd64 go build ${CFLAGS} -o $(WINDOWS)  -ldflags=$(LD_FLAGS)  cmd/kam/kam.go
+	env GOOS=windows GOARCH=amd64 go build ${CFLAGS} -o $(DIST_DIR)/$(WINDOWS)  -ldflags=$(LD_FLAGS)  cmd/kam/kam.go
 
 $(LINUX):
-	env GOOS=linux GOARCH=amd64 go build  ${CFLAGS} -o $(LINUX)  -ldflags=$(LD_FLAGS) cmd/kam/kam.go
+	env GOOS=linux GOARCH=amd64 go build  ${CFLAGS} -o $(DIST_DIR)/$(LINUX)  -ldflags=$(LD_FLAGS) cmd/kam/kam.go
 
 $(DARWIN):
-	env GOOS=darwin GOARCH=amd64 go build  ${CFLAGS} -o $(DARWIN) -ldflags=$(LD_FLAGS) cmd/kam/kam.go	
+	env GOOS=darwin GOARCH=amd64 go build  ${CFLAGS} -o $(DIST_DIR)/$(DARWIN) -ldflags=$(LD_FLAGS) cmd/kam/kam.go	
 
 default: bin
 
@@ -43,7 +44,7 @@ gofmt:
 
 .PHONY: bin
 bin:
-	go build  ${CFLAGS} -o $(EXECUTABLE) -ldflags=$(LD_FLAGS) cmd/kam/kam.go 
+	go build  ${CFLAGS} -o $(DIST_DIR)/$(EXECUTABLE) -ldflags=$(LD_FLAGS) cmd/kam/kam.go 
 
 .PHONY: install
 install:
@@ -55,7 +56,7 @@ test:
 
 .PHONY: clean
 clean:
-	@rm -f $(WINDOWS) $(LINUX) $(DARWIN) ${EXECUTABLE} 
+	@rm -f $(DIST_DIR)/$(WINDOWS) $(DIST_DIR)/$(LINUX) $(DIST_DIR)/$(DARWIN) $(DIST_DIR)/${EXECUTABLE} 
 	
 .PHONY: openshiftci-presubmit-unittests
 openshiftci-presubmit-unittests:

--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ test:
 
 .PHONY: clean
 clean:
-	@rm -f $(DIST_DIR)/$(WINDOWS) $(DIST_DIR)/$(LINUX) $(DIST_DIR)/$(DARWIN) $(DIST_DIR)/${EXECUTABLE} 
+	@rm -f $(DIST_DIR)/*
 	
 .PHONY: openshiftci-presubmit-unittests
 openshiftci-presubmit-unittests:

--- a/scripts/openshiftci-presubmit-all-tests.sh
+++ b/scripts/openshiftci-presubmit-all-tests.sh
@@ -8,7 +8,7 @@ set -x
 export CI="prow"
 make prepare-test-cluster
 make bin
-export PATH="$PATH:$(pwd)"
+export PATH="$PATH:$(pwd)/dist"
 export ARTIFACTS_DIR="/tmp/artifacts"
 export CUSTOM_HOMEDIR=$ARTIFACTS_DIR
 

--- a/scripts/openshiftci-presubmit-all-tests.sh
+++ b/scripts/openshiftci-presubmit-all-tests.sh
@@ -8,7 +8,7 @@ set -x
 export CI="prow"
 make prepare-test-cluster
 make bin
-export PATH="$PATH:$(pwd)/dist"
+export PATH="$PATH:$(pwd)/bin"
 export ARTIFACTS_DIR="/tmp/artifacts"
 export CUSTOM_HOMEDIR=$ARTIFACTS_DIR
 

--- a/scripts/openshiftci-presubmit-unittests.sh
+++ b/scripts/openshiftci-presubmit-unittests.sh
@@ -29,6 +29,6 @@ fi
 # crosscompile and publish artifacts
 make all_platforms
 
-cp kam_darwin_amd64 $CUSTOM_HOMEDIR
-cp kam_linux_amd64 $CUSTOM_HOMEDIR
-cp kam_windows_amd64.exe $CUSTOM_HOMEDIR
+cp dist/kam_darwin_amd64 $CUSTOM_HOMEDIR
+cp dist/kam_linux_amd64 $CUSTOM_HOMEDIR
+cp dist/kam_windows_amd64.exe $CUSTOM_HOMEDIR


### PR DESCRIPTION
**What type of PR is this?**
/kind enhancement

**What does this PR do / why we need it**:
This PR changes the location of where binaries are outputted.   Instead of putting the built binaries (kam, etc) in the top level folder, they are not put in the "dist" folder.   .gitIngore file is updated to ignore files in "dist" folder.

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:
* Remove any `kam` binary at the top level folder.
* Run `make bin` to compile `kam`
* Check built file `ls -l dist`
* Run `make clean` 
* Check binaries are removed `ls -l dist`
