### PR TITLE
Remove unnecessary make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,10 +57,6 @@ test:
 clean:
 	@rm -f $(WINDOWS) $(LINUX) $(DARWIN) ${EXECUTABLE} 
 	
-.PHONY: openshiftci-presubmit-unittests
-openshiftci-presubmit-unittests:
-	./scripts/openshiftci-presubmit-unittests.sh
-
 .PHONY: cmd-docs
 cmd-docs:
 	go run -mod=readonly tools/cmd-docs/main.go


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What does this PR do / why we need it**:
```openshiftci-presubmit-unittests.sh``` is written for CI operation, so we should not expose it in the make target as it gives a wrong message that this target can be run for local environment. So removing it.

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes https://github.com/redhat-developer/kam/pull/68#discussion_r509924498

**How to test changes / Special notes to the reviewer**:
CI should not fail. 