### PR TITLE
Adding argocd install script that can be referenced from other E2E tests

### DIFF
--- a/scripts/install-argocd.sh
+++ b/scripts/install-argocd.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-set -e
 
 # Find the latest ArgoCD version
 VERSION=$(curl --silent "https://api.github.com/repos/argoproj/argo-cd/releases/latest" | grep '"tag_name"' | sed -E 's/.*"([^"]+)".*/\1/')

--- a/scripts/install-argocd.sh
+++ b/scripts/install-argocd.sh
@@ -9,7 +9,7 @@ PLATFORM=`uname -s | awk '{print tolower($0)}'`
 echo $PLATFORM 
 
 # Fetch the appropriate OS binary for ArgoCD
-curl -sSL -o argocd https://github.com/argoproj/argo-cd/releases/download/$VERSION/argocd-$PLATFORM-amd64
+curl -sSL -o bin/argocd https://github.com/argoproj/argo-cd/releases/download/$VERSION/argocd-$PLATFORM-amd64
 
 # Make the argocd CLI executable
 chmod +x argocd

--- a/scripts/install-argocd.sh
+++ b/scripts/install-argocd.sh
@@ -1,29 +1,16 @@
 #!/bin/bash
 set -e
 
-if [[ "$ARGOCD_SERVER" == "" ]]; then
- echo "ArgoCD server address unspecified!"
- exit 1
-fi
-
-echo "Removing previous argocd installation from path (if any)..."
-rm /usr/local/bin/argocd
-
-echo "Starting argocd installation..."
-
-# Not considering the Windows binary for now
-OS_NAME=$(uname -s)
-
 # Find the latest ArgoCD version
 VERSION=$(curl --silent "https://api.github.com/repos/argoproj/argo-cd/releases/latest" | grep '"tag_name"' | sed -E 's/.*"([^"]+)".*/\1/')
+echo $VERSION
+
+# Platform check
+PLATFORM=`uname -s | awk '{print tolower($0)}'`
+echo $PLATFORM 
 
 # Fetch the appropriate OS binary for ArgoCD
-
-curl -sSL -o /usr/local/bin/argocd https://github.com/argoproj/argo-cd/releases/download/$VERSION/argocd-$OS_NAME-amd64
+curl -sSL -o argocd https://github.com/argoproj/argo-cd/releases/download/$VERSION/argocd-$PLATFORM-amd64
 
 # Make the argocd CLI executable
-
-chmod +x /usr/local/bin/argocd
-
-# Simple check to see if Argocd binary works
-argocd version
+chmod +x argocd

--- a/scripts/install-argocd.sh
+++ b/scripts/install-argocd.sh
@@ -12,4 +12,4 @@ echo $PLATFORM
 curl -sSL -o bin/argocd https://github.com/argoproj/argo-cd/releases/download/$VERSION/argocd-$PLATFORM-amd64
 
 # Make the argocd CLI executable
-chmod +x argocd
+chmod +x bin/argocd

--- a/scripts/install-argocd.sh
+++ b/scripts/install-argocd.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+set -e
+
+if [[ "$ARGOCD_SERVER" == "" ]]; then
+ echo "ArgoCD server address unspecified!"
+ exit 1
+fi
+
+echo "Removing previous argocd installation from path (if any)..."
+rm /usr/local/bin/argocd
+
+echo "Starting argocd installation..."
+
+# Not considering the Windows binary for now
+OS_NAME=$(uname -s)
+
+# Find the latest ArgoCD version
+VERSION=$(curl --silent "https://api.github.com/repos/argoproj/argo-cd/releases/latest" | grep '"tag_name"' | sed -E 's/.*"([^"]+)".*/\1/')
+
+# Fetch the appropriate OS binary for ArgoCD
+
+curl -sSL -o /usr/local/bin/argocd https://github.com/argoproj/argo-cd/releases/download/$VERSION/argocd-$OS_NAME-amd64
+
+# Make the argocd CLI executable
+
+chmod +x /usr/local/bin/argocd
+
+# Simple check to see if Argocd binary works
+argocd version

--- a/scripts/openshiftci-presubmit-all-tests.sh
+++ b/scripts/openshiftci-presubmit-all-tests.sh
@@ -12,7 +12,7 @@ make bin
 INSTALL_ARGOCD="./scripts/install-argocd.sh"
 sh $INSTALL_ARGOCD
 
-export PATH="$PATH:$(pwd)"
+export PATH="$PATH:$(pwd)/bin"
 export ARTIFACTS_DIR="/tmp/artifacts"
 export CUSTOM_HOMEDIR=$ARTIFACTS_DIR
 

--- a/scripts/openshiftci-presubmit-all-tests.sh
+++ b/scripts/openshiftci-presubmit-all-tests.sh
@@ -8,6 +8,10 @@ set -x
 export CI="prow"
 make prepare-test-cluster
 make bin
+
+INSTALL_ARGOCD="./scripts/install-argocd.sh"
+sh $INSTALL_ARGOCD
+
 export PATH="$PATH:$(pwd)"
 export ARTIFACTS_DIR="/tmp/artifacts"
 export CUSTOM_HOMEDIR=$ARTIFACTS_DIR


### PR DESCRIPTION
**What type of PR is this?**
/kind enhancement

**What does this PR do / why we need it**:
This PR adds a script to install ArgoCD on darwin/linux that's needed as part of GITOPS-333 issue.

**Have you updated the necessary documentation?**

Documentation will be updated once the entire work is completed for GITOPS-333.

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:
[GITOPS-333](https://issues.redhat.com/projects/GITOPS/issues/GITOPS-333) partial.

**How to test changes / Special notes to the reviewer**:
Execute this script on mac/linux where you don't have ArgoCD installed. The script will install ArgoCD CLI. Since the ArgoCD server address is not set, you might see an error at the end. But the goal of this script is to install ArgoCD CLI.