### PR TITLE
Adding Docker CLI install script 

### DIFF
--- a/scripts/install-argocd.sh
+++ b/scripts/install-argocd.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-set -e
 
 # Find the latest ArgoCD version
 VERSION=$(curl --silent "https://api.github.com/repos/argoproj/argo-cd/releases/latest" | grep '"tag_name"' | sed -E 's/.*"([^"]+)".*/\1/')

--- a/scripts/install-argocd.sh
+++ b/scripts/install-argocd.sh
@@ -9,7 +9,7 @@ PLATFORM=`uname -s | awk '{print tolower($0)}'`
 echo $PLATFORM 
 
 # Fetch the appropriate OS binary for ArgoCD
-curl -sSL -o argocd https://github.com/argoproj/argo-cd/releases/download/$VERSION/argocd-$PLATFORM-amd64
+curl -sSL -o bin/argocd https://github.com/argoproj/argo-cd/releases/download/$VERSION/argocd-$PLATFORM-amd64
 
 # Make the argocd CLI executable
 chmod +x argocd

--- a/scripts/install-argocd.sh
+++ b/scripts/install-argocd.sh
@@ -1,29 +1,16 @@
 #!/bin/bash
 set -e
 
-if [[ "$ARGOCD_SERVER" == "" ]]; then
- echo "ArgoCD server address unspecified!"
- exit 1
-fi
-
-echo "Removing previous argocd installation from path (if any)..."
-rm /usr/local/bin/argocd
-
-echo "Starting argocd installation..."
-
-# Not considering the Windows binary for now
-OS_NAME=$(uname -s)
-
 # Find the latest ArgoCD version
 VERSION=$(curl --silent "https://api.github.com/repos/argoproj/argo-cd/releases/latest" | grep '"tag_name"' | sed -E 's/.*"([^"]+)".*/\1/')
+echo $VERSION
+
+# Platform check
+PLATFORM=`uname -s | awk '{print tolower($0)}'`
+echo $PLATFORM 
 
 # Fetch the appropriate OS binary for ArgoCD
-
-curl -sSL -o /usr/local/bin/argocd https://github.com/argoproj/argo-cd/releases/download/$VERSION/argocd-$OS_NAME-amd64
+curl -sSL -o argocd https://github.com/argoproj/argo-cd/releases/download/$VERSION/argocd-$PLATFORM-amd64
 
 # Make the argocd CLI executable
-
-chmod +x /usr/local/bin/argocd
-
-# Simple check to see if Argocd binary works
-argocd version
+chmod +x argocd

--- a/scripts/install-argocd.sh
+++ b/scripts/install-argocd.sh
@@ -12,4 +12,4 @@ echo $PLATFORM
 curl -sSL -o bin/argocd https://github.com/argoproj/argo-cd/releases/download/$VERSION/argocd-$PLATFORM-amd64
 
 # Make the argocd CLI executable
-chmod +x argocd
+chmod +x bin/argocd

--- a/scripts/install-argocd.sh
+++ b/scripts/install-argocd.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+set -e
+
+if [[ "$ARGOCD_SERVER" == "" ]]; then
+ echo "ArgoCD server address unspecified!"
+ exit 1
+fi
+
+echo "Removing previous argocd installation from path (if any)..."
+rm /usr/local/bin/argocd
+
+echo "Starting argocd installation..."
+
+# Not considering the Windows binary for now
+OS_NAME=$(uname -s)
+
+# Find the latest ArgoCD version
+VERSION=$(curl --silent "https://api.github.com/repos/argoproj/argo-cd/releases/latest" | grep '"tag_name"' | sed -E 's/.*"([^"]+)".*/\1/')
+
+# Fetch the appropriate OS binary for ArgoCD
+
+curl -sSL -o /usr/local/bin/argocd https://github.com/argoproj/argo-cd/releases/download/$VERSION/argocd-$OS_NAME-amd64
+
+# Make the argocd CLI executable
+
+chmod +x /usr/local/bin/argocd
+
+# Simple check to see if Argocd binary works
+argocd version

--- a/scripts/install-docker-cli.sh
+++ b/scripts/install-docker-cli.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# Platform check
+PLATFORM=`uname -s | awk '{print tolower($0)}'`
+echo "Your platform is $PLATFORM" 
+
+DOCKER_VERSION=$(curl --silent "https://api.github.com/repos/docker/docker-ce/releases/latest" | grep '"tag_name"' | sed -E 's/.*"([^"]+)".*/\1/' | cut -c2-9)
+DOCKER_LATEST_BINARY="docker-$VERSION.tgz"
+
+if [ $PLATFORM == "darwin" ]
+then
+    curl -sSL -o bin/docker https://download.docker.com/mac/static/stable/x86_64/$DOCKER_BINARY
+elif [ $PLATFORM == "linux" ]
+then
+    curl -sSL -o bin/docker https://download.docker.com/linux/static/stable/x86_64/$DOCKER_BINARY
+else
+    echo "Your OS is unsupported for installing required dependency."
+fi
+
+# Make the docker CLI executable
+chmod +x bin/docker

--- a/scripts/openshiftci-presubmit-all-tests.sh
+++ b/scripts/openshiftci-presubmit-all-tests.sh
@@ -12,7 +12,7 @@ make bin
 INSTALL_ARGOCD="./scripts/install-argocd.sh"
 sh $INSTALL_ARGOCD
 
-export PATH="$PATH:$(pwd)"
+export PATH="$PATH:$(pwd)/bin"
 export ARTIFACTS_DIR="/tmp/artifacts"
 export CUSTOM_HOMEDIR=$ARTIFACTS_DIR
 

--- a/scripts/openshiftci-presubmit-all-tests.sh
+++ b/scripts/openshiftci-presubmit-all-tests.sh
@@ -12,6 +12,9 @@ make bin
 INSTALL_ARGOCD="./scripts/install-argocd.sh"
 sh $INSTALL_ARGOCD
 
+INSTALL_DOCKER="./scripts/install-docker-cli.sh"
+sh $INSTALL_DOCKER
+
 export PATH="$PATH:$(pwd)/bin"
 export ARTIFACTS_DIR="/tmp/artifacts"
 export CUSTOM_HOMEDIR=$ARTIFACTS_DIR

--- a/scripts/openshiftci-presubmit-all-tests.sh
+++ b/scripts/openshiftci-presubmit-all-tests.sh
@@ -8,6 +8,10 @@ set -x
 export CI="prow"
 make prepare-test-cluster
 make bin
+
+INSTALL_ARGOCD="./scripts/install-argocd.sh"
+sh $INSTALL_ARGOCD
+
 export PATH="$PATH:$(pwd)"
 export ARTIFACTS_DIR="/tmp/artifacts"
 export CUSTOM_HOMEDIR=$ARTIFACTS_DIR


### PR DESCRIPTION
**What type of PR is this?**

/kind enhancement

**What does this PR do / why we need it**:

Adding Docker CLI install script that can be referenced from other E2E tests.

**Have you updated the necessary documentation?**

* [ ] Documentation update is not required by this PR. The update will happen once the parent task is completed.

**Which issue(s) this PR fixes**:

Partial of https://issues.redhat.com/browse/GITOPS-333

Fixes #?

N/A

**How to test changes / Special notes to the reviewer**:

Execute this script on your Mac or Linux machine. The script worked for me when I did not include the `bin/docker` part and used just `docker`. Added `bin/docker` to match the KAM CLI.