### PR TITLE
Allow kam commands to reuse Git auth-token

### DIFF
--- a/docs/commands/kam_bootstrap.md
+++ b/docs/commands/kam_bootstrap.md
@@ -33,7 +33,7 @@ kam bootstrap [flags]
   -p, --prefix string                                  Add a prefix to the environment names(Dev, stage,prod,cicd etc.) to distinguish and identify individual environments
       --private-repo-driver string                     If your Git repositories are on a custom domain, please indicate which driver to use github or gitlab
       --push-to-git                                    If true, automatically creates and populates the gitops-repo-url with the generated resources
-      --save-token-keyring string                      Explicitely pass this flag to update the git-host-access-token in the keyring on your local file system
+      --save-token-keyring                             Explicitely pass this flag to update the git-host-access-token in the keyring on your local file system
       --sealed-secrets-ns string                       Namespace in which the Sealed Secrets operator is installed, automatically generated secrets are encrypted with this operator (default "cicd")
       --sealed-secrets-svc string                      Name of the Sealed Secrets Services that encrypts secrets (default "sealedsecretcontroller-sealed-secrets")
       --service-repo-url string                        Provide the URL for your Service repository e.g. https://github.com/organisation/service.git

--- a/docs/commands/kam_bootstrap.md
+++ b/docs/commands/kam_bootstrap.md
@@ -22,7 +22,7 @@ kam bootstrap [flags]
 ```
       --commit-status-tracker                          Enable or disable the commit-status-tracker which reports the success/failure of your pipelineruns to GitHub/GitLab (default true)
       --dockercfgjson string                           Filepath to config.json which authenticates the image push to the desired image registry  (default "~/.docker/config.json")
-      --git-host-access-token string                   Used to authenticate repository clones, and commit-status notifications (if enabled). Access token will be updated in the keyring
+      --git-host-access-token string                   Used to authenticate repository clones, and commit-status notifications (if enabled). Access token is encrypted and stored on local file system by keyring, will be updated/reused.
       --gitops-repo-url string                         Provide the URL for your GitOps repository e.g. https://github.com/organisation/repository.git
       --gitops-webhook-secret string                   Provide a secret that we can use to authenticate incoming hooks from your Git hosting service for the GitOps repository. (if not provided, it will be auto-generated)
   -h, --help                                           help for bootstrap

--- a/docs/commands/kam_bootstrap.md
+++ b/docs/commands/kam_bootstrap.md
@@ -20,6 +20,7 @@ kam bootstrap [flags]
 ### Options
 
 ```
+      --SaveTokenKeyring                               Explicitely pass this flag to update the git-host-access-token in the keyring on your local file system
       --commit-status-tracker                          Enable or disable the commit-status-tracker which reports the success/failure of your pipelineruns to GitHub/GitLab (default true)
       --dockercfgjson string                           Filepath to config.json which authenticates the image push to the desired image registry  (default "~/.docker/config.json")
       --git-host-access-token string                   Used to authenticate repository clones, and commit-status notifications (if enabled). Access token is encrypted and stored on local file system by keyring, will be updated/reused.
@@ -33,7 +34,6 @@ kam bootstrap [flags]
   -p, --prefix string                                  Add a prefix to the environment names(Dev, stage,prod,cicd etc.) to distinguish and identify individual environments
       --private-repo-driver string                     If your Git repositories are on a custom domain, please indicate which driver to use github or gitlab
       --push-to-git                                    If true, automatically creates and populates the gitops-repo-url with the generated resources
-      --save-token-keyring                             Explicitely pass this flag to update the git-host-access-token in the keyring on your local file system
       --sealed-secrets-ns string                       Namespace in which the Sealed Secrets operator is installed, automatically generated secrets are encrypted with this operator (default "cicd")
       --sealed-secrets-svc string                      Name of the Sealed Secrets Services that encrypts secrets (default "sealedsecretcontroller-sealed-secrets")
       --service-repo-url string                        Provide the URL for your Service repository e.g. https://github.com/organisation/service.git

--- a/docs/commands/kam_bootstrap.md
+++ b/docs/commands/kam_bootstrap.md
@@ -22,7 +22,7 @@ kam bootstrap [flags]
 ```
       --commit-status-tracker                          Enable or disable the commit-status-tracker which reports the success/failure of your pipelineruns to GitHub/GitLab (default true)
       --dockercfgjson string                           Filepath to config.json which authenticates the image push to the desired image registry  (default "~/.docker/config.json")
-      --git-host-access-token string                   Used to authenticate repository clones, and commit-status notifications (if enabled). Will update the token in the keyring if present.
+      --git-host-access-token string                   Used to authenticate repository clones, and commit-status notifications (if enabled). Access token will be updated in the keyring
       --gitops-repo-url string                         Provide the URL for your GitOps repository e.g. https://github.com/organisation/repository.git
       --gitops-webhook-secret string                   Provide a secret that we can use to authenticate incoming hooks from your Git hosting service for the GitOps repository. (if not provided, it will be auto-generated)
   -h, --help                                           help for bootstrap

--- a/docs/commands/kam_bootstrap.md
+++ b/docs/commands/kam_bootstrap.md
@@ -22,7 +22,7 @@ kam bootstrap [flags]
 ```
       --commit-status-tracker                          Enable or disable the commit-status-tracker which reports the success/failure of your pipelineruns to GitHub/GitLab (default true)
       --dockercfgjson string                           Filepath to config.json which authenticates the image push to the desired image registry  (default "~/.docker/config.json")
-      --git-host-access-token string                   Used to authenticate repository clones, and commit-status notifications (if enabled)
+      --git-host-access-token string                   Used to authenticate repository clones, and commit-status notifications (if enabled). Will update the token in the keyring if present.
       --gitops-repo-url string                         Provide the URL for your GitOps repository e.g. https://github.com/organisation/repository.git
       --gitops-webhook-secret string                   Provide a secret that we can use to authenticate incoming hooks from your Git hosting service for the GitOps repository. (if not provided, it will be auto-generated)
   -h, --help                                           help for bootstrap

--- a/docs/commands/kam_bootstrap.md
+++ b/docs/commands/kam_bootstrap.md
@@ -20,7 +20,7 @@ kam bootstrap [flags]
 ### Options
 
 ```
-      --commit-status-tracker                          Enable or disable the commit-status-tracker which reports the success/failure of your pipelineruns to GitHub/GitLab (default true)
+      --commit-status-tracker                          Enable or disable the commit-status-tracker which reports the success/failure of your pipelineruns to GitHub/GitLab
       --dockercfgjson string                           Filepath to config.json which authenticates the image push to the desired image registry  (default "~/.docker/config.json")
       --git-host-access-token string                   Used to authenticate repository clones, and commit-status notifications (if enabled)
       --gitops-repo-url string                         Provide the URL for your GitOps repository e.g. https://github.com/organisation/repository.git

--- a/docs/commands/kam_bootstrap.md
+++ b/docs/commands/kam_bootstrap.md
@@ -33,6 +33,7 @@ kam bootstrap [flags]
   -p, --prefix string                                  Add a prefix to the environment names(Dev, stage,prod,cicd etc.) to distinguish and identify individual environments
       --private-repo-driver string                     If your Git repositories are on a custom domain, please indicate which driver to use github or gitlab
       --push-to-git                                    If true, automatically creates and populates the gitops-repo-url with the generated resources
+      --save-token-keyring string                      Explicitely pass this flag to update the git-host-access-token in the keyring on your local file system
       --sealed-secrets-ns string                       Namespace in which the Sealed Secrets operator is installed, automatically generated secrets are encrypted with this operator (default "cicd")
       --sealed-secrets-svc string                      Name of the Sealed Secrets Services that encrypts secrets (default "sealedsecretcontroller-sealed-secrets")
       --service-repo-url string                        Provide the URL for your Service repository e.g. https://github.com/organisation/service.git

--- a/docs/commands/kam_bootstrap.md
+++ b/docs/commands/kam_bootstrap.md
@@ -22,7 +22,7 @@ kam bootstrap [flags]
 ```
       --commit-status-tracker                          Enable or disable the commit-status-tracker which reports the success/failure of your pipelineruns to GitHub/GitLab
       --dockercfgjson string                           Filepath to config.json which authenticates the image push to the desired image registry  (default "~/.docker/config.json")
-      --git-host-access-token string                   Used to authenticate repository clones, and commit-status notifications (if enabled)
+      --git-host-access-token string                   Used to authenticate repository clones, and commit-status notifications.(if enabled). Creates/Overrides the keyring token in your local file system.
       --gitops-repo-url string                         Provide the URL for your GitOps repository e.g. https://github.com/organisation/repository.git
       --gitops-webhook-secret string                   Provide a secret that we can use to authenticate incoming hooks from your Git hosting service for the GitOps repository. (if not provided, it will be auto-generated)
   -h, --help                                           help for bootstrap

--- a/docs/commands/kam_bootstrap.md
+++ b/docs/commands/kam_bootstrap.md
@@ -20,9 +20,9 @@ kam bootstrap [flags]
 ### Options
 
 ```
-      --commit-status-tracker                          Enable or disable the commit-status-tracker which reports the success/failure of your pipelineruns to GitHub/GitLab
+      --commit-status-tracker                          Enable or disable the commit-status-tracker which reports the success/failure of your pipelineruns to GitHub/GitLab (default true)
       --dockercfgjson string                           Filepath to config.json which authenticates the image push to the desired image registry  (default "~/.docker/config.json")
-      --git-host-access-token string                   Used to authenticate repository clones, and commit-status notifications.(if enabled). Creates/Overrides the keyring token in your local file system.
+      --git-host-access-token string                   Used to authenticate repository clones, and commit-status notifications (if enabled)
       --gitops-repo-url string                         Provide the URL for your GitOps repository e.g. https://github.com/organisation/repository.git
       --gitops-webhook-secret string                   Provide a secret that we can use to authenticate incoming hooks from your Git hosting service for the GitOps repository. (if not provided, it will be auto-generated)
   -h, --help                                           help for bootstrap

--- a/docs/commands/kam_webhook.md
+++ b/docs/commands/kam_webhook.md
@@ -9,6 +9,13 @@ Add/Delete/list Git repository webhooks that trigger CI/CD pipeline runs.
 ```
 kam webhook [flags]
 ```
+* When a token is provided in command flag `--access-token`, the token will be stored securely in keyring. The hostname of the URL (e.g. github.com) will be used to store the token by keyring. The provided token will be used.
+
+* When a token is not provided in command flag `--access-token`, the token is retrieved by keyring using the `hostname of the URL` as the username and service name `kam`. If no token is not found in the keyring, a token is retrieved from environment variable as described in the step below.
+
+* When a token is not provided in command flag and the token is not present in the keyring, the webhook cmd will look for the access token in an environment variable with the syntax HOSTNAME_TOKEN (e.g. GITHUB_COM_TOKEN). The environment variable name is assigned as follows, the hostname (e.g. github.com) is extracted from the value passed to the repository URL (e.g. https://github.com/username/repo.git),  where the `.` in the hostname is replaced by `_` and concatenated with `_TOKEN`. Considering the previous examples, the environment varaible name will be `GITHUB_COM_TOKEN`.
+
+Assuming the token is not passed in the command, if the token is not found in the keyring or the environment variable with the specified name. The command will fail.
 
 ### Examples
 

--- a/docs/commands/kam_webhook.md
+++ b/docs/commands/kam_webhook.md
@@ -10,6 +10,12 @@ Add/Delete/list Git repository webhooks that trigger CI/CD pipeline runs.
 kam webhook [flags]
 ```
 
+* When a token is provided in command flag `--access-token`, the token will be stored securely in keyring. The hostname of the URL (e.g. github.com) will be used to stored the token by keyring. The provided token will be used.
+
+* When a token is not provided in command flag `--access-token`, the token is retrieved by keyring using the hostname of the URL. If no token is not found, a token is retrieved from env var. What is the format of the env var? If no token is not found in the env var, the command will fail.
+
+* When a token is not provided in command flag and the token is not present in the keyring, the webhook cmd will look for the access token in an environment variable with the syntax `HOSTNAME_TOKEN` (e.g. GITHUB_COM_TOKEN).
+
 ### Examples
 
 ```

--- a/docs/commands/kam_webhook.md
+++ b/docs/commands/kam_webhook.md
@@ -10,12 +10,6 @@ Add/Delete/list Git repository webhooks that trigger CI/CD pipeline runs.
 kam webhook [flags]
 ```
 
-* When a token is provided in command flag `--access-token`, the token will be stored securely in keyring. The hostname of the URL (e.g. github.com) will be used to stored the token by keyring. The provided token will be used.
-
-* When a token is not provided in command flag `--access-token`, the token is retrieved by keyring using the hostname of the URL. If no token is not found, a token is retrieved from env var. What is the format of the env var? If no token is not found in the env var, the command will fail.
-
-* When a token is not provided in command flag and the token is not present in the keyring, the webhook cmd will look for the access token in an environment variable with the syntax `HOSTNAME_TOKEN` (e.g. GITHUB_COM_TOKEN).
-
 ### Examples
 
 ```

--- a/docs/commands/kam_webhook.md
+++ b/docs/commands/kam_webhook.md
@@ -9,13 +9,6 @@ Add/Delete/list Git repository webhooks that trigger CI/CD pipeline runs.
 ```
 kam webhook [flags]
 ```
-* When a token is provided in command flag `--access-token`, the token will be stored securely in keyring. The hostname of the URL (e.g. github.com) will be used to store the token by keyring. The provided token will be used.
-
-* When a token is not provided in command flag `--access-token`, the token is retrieved by keyring using the `hostname of the URL` as the username and service name `kam`. If no token is not found in the keyring, a token is retrieved from environment variable as described in the step below.
-
-* When a token is not provided in command flag and the token is not present in the keyring, the webhook cmd will look for the access token in an environment variable with the syntax HOSTNAME_TOKEN (e.g. GITHUB_COM_TOKEN). The environment variable name is assigned as follows, the hostname (e.g. github.com) is extracted from the value passed to the repository URL (e.g. https://github.com/username/repo.git),  where the `.` in the hostname is replaced by `_` and concatenated with `_TOKEN`. Considering the previous examples, the environment varaible name will be `GITHUB_COM_TOKEN`.
-
-Assuming the token is not passed in the command, if the token is not found in the keyring or the environment variable with the specified name. The command will fail.
 
 ### Examples
 

--- a/docs/commands/kam_webhook.md
+++ b/docs/commands/kam_webhook.md
@@ -9,6 +9,10 @@ Add/Delete/list Git repository webhooks that trigger CI/CD pipeline runs.
 ```
 kam webhook [flags]
 ```
+#### Important note:
+
+The webhoook command first searches for the personal-access-token(a.k.a access-token) in the key-ring on your local file system. The secret is stored at the time of bootsrap with the following credentials service name ```kam``` and username being the hostname of the gitops-repo. Eg. ```github.com``` being the hostname for gitops repo  ```URL: https://github.com/user/abc.git``` . If the git-host-access-token is not found in the keyring, it looks for the access-token in an environment variable with the name ```[REPO-NAME]GITTOKEN```. Eg. For the aforementioned ```URL: https://github.com/user/abc.git```, the name of the environment variable that is expected to possess the access-token is ```ABCGITTOKEN```. Kindly note, this behavior can be overriden by passing the ```access-token``` flag.
+
 
 ### Examples
 

--- a/docs/commands/kam_webhook.md
+++ b/docs/commands/kam_webhook.md
@@ -9,10 +9,6 @@ Add/Delete/list Git repository webhooks that trigger CI/CD pipeline runs.
 ```
 kam webhook [flags]
 ```
-#### Important note:
-
-The webhoook command first searches for the personal-access-token(a.k.a access-token) in the key-ring on your local file system. The secret is stored at the time of bootsrap with the following credentials service name ```kam``` and username being the hostname of the gitops-repo. Eg. ```github.com``` being the hostname for gitops repo  ```URL: https://github.com/user/abc.git``` . If the git-host-access-token is not found in the keyring, it looks for the access-token in an environment variable with the name ```[REPO-NAME]GITTOKEN```. Eg. For the aforementioned ```URL: https://github.com/user/abc.git```, the name of the environment variable that is expected to possess the access-token is ```ABCGITTOKEN```. Kindly note, this behavior can be overriden by passing the ```access-token``` flag.
-
 
 ### Examples
 

--- a/docs/commands/kam_webhook_create.md
+++ b/docs/commands/kam_webhook_create.md
@@ -20,12 +20,12 @@ kam webhook create [flags]
 ### Options
 
 ```
-      --access-token string       Access token to be used to create Git repository webhook. Access token is encrypted and stored on local file system by keyring, will be updated/reused.
-      --cicd                      Provide this flag if the target Git repository is a CI/CD configuration repository
-      --env-name string           Provide environment name if the target Git repository is a service's source repository.
-  -h, --help                      help for create
-      --pipelines-folder string   Folder path to retrieve manifest, eg. /test where manifest exists at /test/pipelines.yaml (default ".")
-      --service-name string       Provide service name if the target Git repository is a service's source repository.
+      --cicd                           Provide this flag if the target Git repository is a CI/CD configuration repository
+      --env-name string                Provide environment name if the target Git repository is a service's source repository.
+      --git-host-access-token string   Access token to be used to create Git repository webhook. Access token is encrypted and stored on local file system by keyring, will be updated/reused.
+  -h, --help                           help for create
+      --pipelines-folder string        Folder path to retrieve manifest, eg. /test where manifest exists at /test/pipelines.yaml (default ".")
+      --service-name string            Provide service name if the target Git repository is a service's source repository.
 ```
 
 ### SEE ALSO

--- a/docs/commands/kam_webhook_create.md
+++ b/docs/commands/kam_webhook_create.md
@@ -20,7 +20,7 @@ kam webhook create [flags]
 ### Options
 
 ```
-      --access-token string       Access token to be used to create Git repository webhook. Access token will be updated in the keyring
+      --access-token string       Access token to be used to create Git repository webhook. Access token is encrypted and stored on local file system by keyring, will be updated/reused.
       --cicd                      Provide this flag if the target Git repository is a CI/CD configuration repository
       --env-name string           Provide environment name if the target Git repository is a service's source repository.
   -h, --help                      help for create

--- a/docs/commands/kam_webhook_create.md
+++ b/docs/commands/kam_webhook_create.md
@@ -20,7 +20,7 @@ kam webhook create [flags]
 ### Options
 
 ```
-      --access-token string       Access token to be used to create Git repository webhook
+      --access-token string       Access token to be used to create Git repository webhook (will update the token in the keyring if present)
       --cicd                      Provide this flag if the target Git repository is a CI/CD configuration repository
       --env-name string           Provide environment name if the target Git repository is a service's source repository.
   -h, --help                      help for create

--- a/docs/commands/kam_webhook_create.md
+++ b/docs/commands/kam_webhook_create.md
@@ -20,7 +20,7 @@ kam webhook create [flags]
 ### Options
 
 ```
-      --access-token string       Access token to be used to create Git repository webhook (will update the token in the keyring if present)
+      --access-token string       Access token to be used to create Git repository webhook. Access token will be updated in the keyring
       --cicd                      Provide this flag if the target Git repository is a CI/CD configuration repository
       --env-name string           Provide environment name if the target Git repository is a service's source repository.
   -h, --help                      help for create

--- a/docs/commands/kam_webhook_delete.md
+++ b/docs/commands/kam_webhook_delete.md
@@ -20,7 +20,7 @@ kam webhook delete [flags]
 ### Options
 
 ```
-      --access-token string       Access token to be used to create Git repository webhook
+      --access-token string       Access token to be used to create Git repository webhook (will update the token in the keyring if present)
       --cicd                      Provide this flag if the target Git repository is a CI/CD configuration repository
       --env-name string           Provide environment name if the target Git repository is a service's source repository.
   -h, --help                      help for delete

--- a/docs/commands/kam_webhook_delete.md
+++ b/docs/commands/kam_webhook_delete.md
@@ -20,7 +20,7 @@ kam webhook delete [flags]
 ### Options
 
 ```
-      --access-token string       Access token to be used to create Git repository webhook (will update the token in the keyring if present)
+      --access-token string       Access token to be used to create Git repository webhook. Access token will be updated in the keyring
       --cicd                      Provide this flag if the target Git repository is a CI/CD configuration repository
       --env-name string           Provide environment name if the target Git repository is a service's source repository.
   -h, --help                      help for delete

--- a/docs/commands/kam_webhook_delete.md
+++ b/docs/commands/kam_webhook_delete.md
@@ -20,7 +20,7 @@ kam webhook delete [flags]
 ### Options
 
 ```
-      --access-token string       Access token to be used to create Git repository webhook. Access token will be updated in the keyring
+      --access-token string       Access token to be used to create Git repository webhook. Access token is encrypted and stored on local file system by keyring, will be updated/reused.
       --cicd                      Provide this flag if the target Git repository is a CI/CD configuration repository
       --env-name string           Provide environment name if the target Git repository is a service's source repository.
   -h, --help                      help for delete

--- a/docs/commands/kam_webhook_delete.md
+++ b/docs/commands/kam_webhook_delete.md
@@ -20,12 +20,12 @@ kam webhook delete [flags]
 ### Options
 
 ```
-      --access-token string       Access token to be used to create Git repository webhook. Access token is encrypted and stored on local file system by keyring, will be updated/reused.
-      --cicd                      Provide this flag if the target Git repository is a CI/CD configuration repository
-      --env-name string           Provide environment name if the target Git repository is a service's source repository.
-  -h, --help                      help for delete
-      --pipelines-folder string   Folder path to retrieve manifest, eg. /test where manifest exists at /test/pipelines.yaml (default ".")
-      --service-name string       Provide service name if the target Git repository is a service's source repository.
+      --cicd                           Provide this flag if the target Git repository is a CI/CD configuration repository
+      --env-name string                Provide environment name if the target Git repository is a service's source repository.
+      --git-host-access-token string   Access token to be used to create Git repository webhook. Access token is encrypted and stored on local file system by keyring, will be updated/reused.
+  -h, --help                           help for delete
+      --pipelines-folder string        Folder path to retrieve manifest, eg. /test where manifest exists at /test/pipelines.yaml (default ".")
+      --service-name string            Provide service name if the target Git repository is a service's source repository.
 ```
 
 ### SEE ALSO

--- a/docs/commands/kam_webhook_list.md
+++ b/docs/commands/kam_webhook_list.md
@@ -20,7 +20,7 @@ kam webhook list [flags]
 ### Options
 
 ```
-      --access-token string       Access token to be used to create Git repository webhook
+      --access-token string       Access token to be used to create Git repository webhook (will update the token in the keyring if present)
       --cicd                      Provide this flag if the target Git repository is a CI/CD configuration repository
       --env-name string           Provide environment name if the target Git repository is a service's source repository.
   -h, --help                      help for list

--- a/docs/commands/kam_webhook_list.md
+++ b/docs/commands/kam_webhook_list.md
@@ -20,7 +20,7 @@ kam webhook list [flags]
 ### Options
 
 ```
-      --access-token string       Access token to be used to create Git repository webhook. Access token will be updated in the keyring
+      --access-token string       Access token to be used to create Git repository webhook. Access token is encrypted and stored on local file system by keyring, will be updated/reused.
       --cicd                      Provide this flag if the target Git repository is a CI/CD configuration repository
       --env-name string           Provide environment name if the target Git repository is a service's source repository.
   -h, --help                      help for list

--- a/docs/commands/kam_webhook_list.md
+++ b/docs/commands/kam_webhook_list.md
@@ -20,12 +20,12 @@ kam webhook list [flags]
 ### Options
 
 ```
-      --access-token string       Access token to be used to create Git repository webhook. Access token is encrypted and stored on local file system by keyring, will be updated/reused.
-      --cicd                      Provide this flag if the target Git repository is a CI/CD configuration repository
-      --env-name string           Provide environment name if the target Git repository is a service's source repository.
-  -h, --help                      help for list
-      --pipelines-folder string   Folder path to retrieve manifest, eg. /test where manifest exists at /test/pipelines.yaml (default ".")
-      --service-name string       Provide service name if the target Git repository is a service's source repository.
+      --cicd                           Provide this flag if the target Git repository is a CI/CD configuration repository
+      --env-name string                Provide environment name if the target Git repository is a service's source repository.
+      --git-host-access-token string   Access token to be used to create Git repository webhook. Access token is encrypted and stored on local file system by keyring, will be updated/reused.
+  -h, --help                           help for list
+      --pipelines-folder string        Folder path to retrieve manifest, eg. /test where manifest exists at /test/pipelines.yaml (default ".")
+      --service-name string            Provide service name if the target Git repository is a service's source repository.
 ```
 
 ### SEE ALSO

--- a/docs/commands/kam_webhook_list.md
+++ b/docs/commands/kam_webhook_list.md
@@ -20,7 +20,7 @@ kam webhook list [flags]
 ### Options
 
 ```
-      --access-token string       Access token to be used to create Git repository webhook (will update the token in the keyring if present)
+      --access-token string       Access token to be used to create Git repository webhook. Access token will be updated in the keyring
       --cicd                      Provide this flag if the target Git repository is a CI/CD configuration repository
       --env-name string           Provide environment name if the target Git repository is a service's source repository.
   -h, --help                      help for list

--- a/docs/journey/day1/README.md
+++ b/docs/journey/day1/README.md
@@ -41,14 +41,6 @@ The `kam bootstrap` [command](../../commands/kam_bootstrap.md) also provides an 
 
 In the event of using a self-hosted _GitHub Enterprise_ or _GitLab Community/Enterprise Edition_ if the driver name isn't evident from the repository URL, use the `--private-repo-driver` flag to select _github_ or _gitlab_.
 
-* When a token is provided in command flag `--git-host-access-token`, the token will be stored securely in keyring. The hostname of the URL (e.g. github.com) will be used to store the token by keyring. The provided token will be used.
-
-* When a token is not provided in command flag `--git-host-access-token`, the token is retrieved by keyring using the `hostname of the URL` as the username and service name `kam`. If no token is not found in the keyring, a token is retrieved from environment variable as described in the step below.
-
-* When a token is not provided in command flag and the token is not present in the keyring, the webhook cmd will look for the access token in an environment variable with the syntax HOSTNAME_TOKEN (e.g. GITHUB_COM_TOKEN). The environment variable name is assigned as follows, the hostname (e.g. github.com) is extracted from the value passed to the repository URL (e.g. https://github.com/username/repo.git),  where the `.` in the hostname is replaced by `_` and concatenated with `_TOKEN`. Considering the previous examples, the environment varaible name will be `GITHUB_COM_TOKEN`.
-
-Assuming the token is not passed in the command, if the token is not found in the keyring or the environment variable with the specified name. The command will fail.
-
 For more details see the [ArgoCD documentation](https://argoproj.github.io/argo-cd/user-guide/private-repositories).
 
 The bootstrap process generates a fairly large number of files, including a
@@ -76,7 +68,7 @@ resources, and the resources will be pushed to your git hosting service.
 
 * The token is stored securely on the local file-system using key-ring. The key-ring requires a user-name and service-name to store the secret, the KAM tool stores the secret with the service-name `Kam` and the user-name being the `host name` of the pertaining URL (e.g. --gitops-repo-url).
 
-* If the token is set within the keyring, the keyring will not be prompted for in sucessive attempts of the `Bootstrap` and `Webhook` commands. The token can however be updated in the key-ring by passing the relevant flag (e.g. --git-host-access-token) using non-interactive mode.
+* If the token is set within the keyring, the keyring will not be prompted for in sucessive attempts of the `Bootstrap` and `Webhook` commands. The token can however be updated at the time of bootstrap in the key-ring by passing the `--save-token-keyring` flag along with `--git-host-access-token` flag in the non-interactive mode of the bootstrap command.
 
 * When a token is not provided in the command flag, an attempt is made to retrieve the token from the keyring. If unsuccessful, the cmd will look for the access token in an environment variable whose variable naming convention is as follows, the hostname (e.g. github.com) is extracted from the value passed to the repository URL (e.g. https://github.com/username/repo.git),  where the `.` in the hostname is replaced by `_` and concatenated with `_TOKEN`. In this case, the environment varaible name will be `GITHUB_COM_TOKEN`.
 
@@ -259,7 +251,7 @@ to trigger pipeline runs automatically on pushes to your repositories.
 
 ```shell
 $ kam webhook create \
-    --access-token <git host access token> \
+    --git-host-access-token <git host access token> \
     --env-name dev \
     --service-name taxi
 ```
@@ -290,7 +282,7 @@ the GitOps repo.
 
 ```shell
 $ kam webhook create \
-    --access-token <github user access token> \
+    --git-host-access-token <github user access token> \
     --cicd
 ```
 

--- a/docs/journey/day1/README.md
+++ b/docs/journey/day1/README.md
@@ -41,6 +41,8 @@ The `kam bootstrap` [command](../../commands/kam_bootstrap.md) also provides an 
 
 In the event of using a self-hosted _GitHub Enterprise_ or _GitLab Community/Enterprise Edition_ if the driver name isn't evident from the repository URL, use the `--private-repo-driver` flag to select _github_ or _gitlab_.
 
+The personal access token `--git-host-acccess-token` passed in the bootstrap command will be stored in a secure manner in the keyring on your local file system, if the secret with the same host-name  `Eg. github.com` is present in the keyring, the flag will overwrite the current value present in the keyring with the updated git-host-access-token.
+
 For more details see the [ArgoCD documentation](https://argoproj.github.io/argo-cd/user-guide/private-repositories).
 
 The bootstrap process generates a fairly large number of files, including a

--- a/docs/journey/day1/README.md
+++ b/docs/journey/day1/README.md
@@ -72,6 +72,16 @@ Finally, the GitOps repository is created automatically if credentials are
 provided, this will create a private repository for pushing your generated
 resources, and the resources will be pushed to your git hosting service.
 
+## Access Tokens
+
+* The token is stored securely on the local file-system using key-ring. The key-ring requires a user-name and service-name to store the secret, the KAM tool stores the secret with the service-name `Kam` and the user-name being the `host name` of the pertaining URL (e.g. --gitops-repo-url).
+
+* If the token is set within the keyring, the keyring will not be prompted for in sucessive attempts of the `Bootstrap` and `Webhook` commands. The token can however be updated in the key-ring by passing the relevant flag (e.g. --git-host-access-token) using non-interactive mode.
+
+* When a token is not provided in the command flag, an attempt is made to retrieve the token from the keyring. If unsuccessful, the cmd will look for the access token in an environment variable whose variable naming convention is as follows, the hostname (e.g. github.com) is extracted from the value passed to the repository URL (e.g. https://github.com/username/repo.git),  where the `.` in the hostname is replaced by `_` and concatenated with `_TOKEN`. In this case, the environment varaible name will be `GITHUB_COM_TOKEN`.
+
+* In the event a token is not passed in the command, if the token is not found in the keyring or the environment variable with the specified name. The command will fail.
+
 ## Prefixing namespaces
 
 By default, bootstrapping creates `cicd`, `dev`, and `stage` namespaces, these

--- a/docs/journey/day1/README.md
+++ b/docs/journey/day1/README.md
@@ -41,7 +41,8 @@ The `kam bootstrap` [command](../../commands/kam_bootstrap.md) also provides an 
 
 In the event of using a self-hosted _GitHub Enterprise_ or _GitLab Community/Enterprise Edition_ if the driver name isn't evident from the repository URL, use the `--private-repo-driver` flag to select _github_ or _gitlab_.
 
-The personal access token `--git-host-acccess-token` passed in the bootstrap command will be stored in a secure manner in the keyring on your local file system, if the secret with the same host-name  `Eg. github.com` is present in the keyring, the flag will overwrite the current value present in the keyring with the updated git-host-access-token.
+* When a token is provided in command flag `--git-host-access-token`, the token will be stored securely in keyring. The hostname of the URL (e.g. github.com) will be used to stored the token by keyring. The provided token will be used.
+* When a token is not provided in command flag `--git-host-access-token`, the token is retrieved by keyring using the hostname of the URL. If no token is not found, a token is retrieved from env var. What is the format of the env var? If no token is not found in the env var, the command will fail.
 
 For more details see the [ArgoCD documentation](https://argoproj.github.io/argo-cd/user-guide/private-repositories).
 

--- a/docs/journey/day1/README.md
+++ b/docs/journey/day1/README.md
@@ -41,11 +41,13 @@ The `kam bootstrap` [command](../../commands/kam_bootstrap.md) also provides an 
 
 In the event of using a self-hosted _GitHub Enterprise_ or _GitLab Community/Enterprise Edition_ if the driver name isn't evident from the repository URL, use the `--private-repo-driver` flag to select _github_ or _gitlab_.
 
-* When a token is provided in command flag `--git-host-access-token`, the token will be stored securely in keyring. The hostname of the URL (e.g. github.com) will be used to stored the token by keyring. The provided token will be used.
+* When a token is provided in command flag `--git-host-access-token`, the token will be stored securely in keyring. The hostname of the URL (e.g. github.com) will be used to store the token by keyring. The provided token will be used.
 
-* When a token is not provided in command flag `--git-host-access-token`, the token is retrieved by keyring using the hostname of the URL. If no token is not found, a token is retrieved from env var. What is the format of the env var? If no token is not found in the env var, the command will fail.
+* When a token is not provided in command flag `--git-host-access-token`, the token is retrieved by keyring using the `hostname of the URL` as the username and service name `kam`. If no token is not found in the keyring, a token is retrieved from environment variable as described in the step below.
 
-* When a token is not provided in command flag and the token is not present in the keyring, the webhook cmd will look for the access token in an environment variable with the syntax HOSTNAME_TOKEN (e.g. GITHUB_COM_TOKEN).
+* When a token is not provided in command flag and the token is not present in the keyring, the webhook cmd will look for the access token in an environment variable with the syntax HOSTNAME_TOKEN (e.g. GITHUB_COM_TOKEN). The environment variable name is assigned as follows, the hostname (e.g. github.com) is extracted from the value passed to the repository URL (e.g. https://github.com/username/repo.git),  where the `.` in the hostname is replaced by `_` and concatenated with `_TOKEN`. Considering the previous examples, the environment varaible name will be `GITHUB_COM_TOKEN`.
+
+Assuming the token is not passed in the command, if the token is not found in the keyring or the environment variable with the specified name. The command will fail.
 
 For more details see the [ArgoCD documentation](https://argoproj.github.io/argo-cd/user-guide/private-repositories).
 

--- a/docs/journey/day1/README.md
+++ b/docs/journey/day1/README.md
@@ -42,7 +42,10 @@ The `kam bootstrap` [command](../../commands/kam_bootstrap.md) also provides an 
 In the event of using a self-hosted _GitHub Enterprise_ or _GitLab Community/Enterprise Edition_ if the driver name isn't evident from the repository URL, use the `--private-repo-driver` flag to select _github_ or _gitlab_.
 
 * When a token is provided in command flag `--git-host-access-token`, the token will be stored securely in keyring. The hostname of the URL (e.g. github.com) will be used to stored the token by keyring. The provided token will be used.
+
 * When a token is not provided in command flag `--git-host-access-token`, the token is retrieved by keyring using the hostname of the URL. If no token is not found, a token is retrieved from env var. What is the format of the env var? If no token is not found in the env var, the command will fail.
+
+* When a token is not provided in command flag and the token is not present in the keyring, the webhook cmd will look for the access token in an environment variable with the syntax HOSTNAME_TOKEN (e.g. GITHUB_COM_TOKEN).
 
 For more details see the [ArgoCD documentation](https://argoproj.github.io/argo-cd/user-guide/private-repositories).
 

--- a/docs/journey/day2/README.md
+++ b/docs/journey/day2/README.md
@@ -208,6 +208,13 @@ $ kam webhook create \
     --service-name bus \
     --pipelines-folder <path to GitOps folder>
 ```
+* When a token is provided in the webhook command flag `--access-token`, the token will be stored securely in keyring. The hostname of the URL (e.g. github.com) will be used to store the token by keyring. The provided token will be used.	
+
+* When a token is not provided in the webhook command flag `--access-token`, the token is retrieved by keyring using the `hostname of the URL` as the username and service name `kam`. If no token is not found in the keyring, a token is retrieved from environment variable as described in the step below.	
+
+* When a token is not provided in command flag and the token is not present in the keyring, the webhook cmd will look for the access token in an environment variable with the syntax HOSTNAME_TOKEN (e.g. GITHUB_COM_TOKEN). The environment variable name is assigned as follows, the hostname (e.g. github.com) is extracted from the value passed to the repository URL (e.g. https://github.com/username/repo.git),  where the `.` in the hostname is replaced by `_` and concatenated with `_TOKEN`. Considering the previous examples, the environment varaible name will be `GITHUB_COM_TOKEN`.	
+
+Assuming the token is not passed in the command, if the token is not found in the keyring or the environment variable with the specified name. The command will fail.
 
 Make some modifications to the new application source reposiotry and raise a PR.
 

--- a/docs/journey/day2/README.md
+++ b/docs/journey/day2/README.md
@@ -203,14 +203,13 @@ Create a webhook for the new source repository.   This will allow webhook on the
 
 ```shell
 $ kam webhook create \
-    --access-token <git host access token> \
+    --git-host-access-token <git host access token> \
     --env-name new-env \
     --service-name bus \
     --pipelines-folder <path to GitOps folder>
 ```
-* When a token is provided in the webhook command flag `--access-token`, the token will be stored securely in keyring. The hostname of the URL (e.g. github.com) will be used to store the token by keyring. The provided token will be used.	
-
-* When a token is not provided in the webhook command flag `--access-token`, the token is retrieved by keyring using the `hostname of the URL` as the username and service name `kam`. If no token is not found in the keyring, a token is retrieved from environment variable as described in the step below.	
+	
+* When a token is not provided in the webhook command flag `--git-host-access-token`, the token is retrieved from the keyring using the `hostname of the URL` as the username and service name `kam`. If no token found in the keyring, a token is retrieved from environment variable as described in the step below.	
 
 * When a token is not provided in command flag and the token is not present in the keyring, the webhook cmd will look for the access token in an environment variable with the syntax HOSTNAME_TOKEN (e.g. GITHUB_COM_TOKEN). The environment variable name is assigned as follows, the hostname (e.g. github.com) is extracted from the value passed to the repository URL (e.g. https://github.com/username/repo.git),  where the `.` in the hostname is replaced by `_` and concatenated with `_TOKEN`. Considering the previous examples, the environment varaible name will be `GITHUB_COM_TOKEN`.	
 

--- a/go.mod
+++ b/go.mod
@@ -21,8 +21,8 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/spf13/afero v1.2.2
 	github.com/spf13/cobra v1.0.0
-	github.com/tektoncd/pipeline v0.15.2
-	github.com/tektoncd/triggers v0.5.0
+	github.com/tektoncd/pipeline v0.16.3
+	github.com/tektoncd/triggers v0.8.1
 	github.com/zalando/go-keyring v0.1.0
 	gopkg.in/AlecAivazis/survey.v1 v1.8.0
 	k8s.io/api v0.18.2

--- a/go.mod
+++ b/go.mod
@@ -21,8 +21,9 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/spf13/afero v1.2.2
 	github.com/spf13/cobra v1.0.0
-	github.com/tektoncd/pipeline v0.16.3
-	github.com/tektoncd/triggers v0.8.1
+	github.com/tektoncd/pipeline v0.15.2
+	github.com/tektoncd/triggers v0.5.0
+	github.com/zalando/go-keyring v0.1.0
 	gopkg.in/AlecAivazis/survey.v1 v1.8.0
 	k8s.io/api v0.18.2
 	k8s.io/apimachinery v0.18.2

--- a/go.sum
+++ b/go.sum
@@ -805,6 +805,7 @@ github.com/jenkins-x/go-scm v1.5.79/go.mod h1:PCT338UhP/pQ0IeEeMEf/hoLTYKcH7qjGE
 github.com/jenkins-x/go-scm v1.5.117/go.mod h1:PCT338UhP/pQ0IeEeMEf/hoLTYKcH7qjGEKd7jPkeYg=
 github.com/jenkins-x/go-scm v1.5.160 h1:1OixAnfXn+3Ymxq3suALpJq7PilmpxKl62S6mO/woXM=
 github.com/jenkins-x/go-scm v1.5.160/go.mod h1:wJgj7PfgsCs+YAXC0vEj43g48HKf94apSyza62ADxKY=
+github.com/jenkins-x/go-scm v1.5.190 h1:fJKQJmn+WsIcojwFQEorpb7JXFxVJeaYY8y+4lbyweU=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/jimstudt/http-authentication v0.0.0-20140401203705-3eca13d6893a/go.mod h1:wK6yTYYcgjHE1Z1QtXACPDjcFJyBskHEdagmnq3vsP8=
 github.com/jingyugao/rowserrcheck v0.0.0-20191204022205-72ab7603b68a/go.mod h1:xRskid8CManxVta/ALEhJha/pweKBaVG6fWgc0yH25s=

--- a/go.sum
+++ b/go.sum
@@ -129,7 +129,6 @@ github.com/GoogleCloudPlatform/k8s-cloud-provider v0.0.0-20190822182118-27a4ced3
 github.com/GoogleCloudPlatform/testgrid v0.0.1-alpha.3/go.mod h1:f96W2HYy3tiBNV5zbbRc+NczwYHgG1PHXMQfoEWv680=
 github.com/GoogleCloudPlatform/testgrid v0.0.7/go.mod h1:lmtHGBL0M/MLbu1tR9BWV7FGZ1FEFIdPqmJiHNCL7y8=
 github.com/JeffAshton/win_pdh v0.0.0-20161109143554-76bb4ee9f0ab/go.mod h1:3VYc5hodBMJ5+l/7J4xAyMeuM2PNuepvHlGs8yilUCA=
-github.com/MakeNowJust/heredoc v0.0.0-20170808103936-bb23615498cd h1:sjQovDkwrZp8u+gxLtPgKGjk5hCxuy2hrRejBTA9xFU=
 github.com/MakeNowJust/heredoc v0.0.0-20170808103936-bb23615498cd/go.mod h1:64YHyfSL2R96J44Nlwm39UHepQbyR5q10x7iYa1ks2E=
 github.com/MakeNowJust/heredoc v0.0.0-20171113091838-e9091a26100e h1:eb0Pzkt15Bm7f2FFYv7sjY7NPFi3cPkS3tv1CcrFBWA=
 github.com/MakeNowJust/heredoc v0.0.0-20171113091838-e9091a26100e/go.mod h1:64YHyfSL2R96J44Nlwm39UHepQbyR5q10x7iYa1ks2E=
@@ -321,7 +320,6 @@ github.com/coreos/etcd v3.3.15+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc
 github.com/coreos/go-etcd v2.0.0+incompatible/go.mod h1:Jez6KQU2B/sWsbdaef3ED8NzMklzPG4d5KIOhIy30Tk=
 github.com/coreos/go-oidc v2.1.0+incompatible/go.mod h1:CgnwVTmzoESiwO9qyAFEMiHoZ1nMCKZlZ9V6mm3/LKc=
 github.com/coreos/go-semver v0.2.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
-github.com/coreos/go-semver v0.3.0 h1:wkHLiw0WNATZnSG7epLsujiMCgPAc9xhjJ4tgnAxmfM=
 github.com/coreos/go-semver v0.3.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
 github.com/coreos/go-systemd v0.0.0-20180511133405-39ca1b05acc7/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
@@ -1914,7 +1912,6 @@ honnef.co/go/tools v0.0.1-2020.1.4 h1:UoveltGrhghAA7ePc+e+QYDHXrBps2PqFZiHkGR/xK
 honnef.co/go/tools v0.0.1-2020.1.4/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 k8s.io/api v0.17.1 h1:i46MidoDOE9tvQ0TTEYggf3ka/pziP1+tHI/GFVeJao=
 k8s.io/api v0.17.1/go.mod h1:zxiAc5y8Ngn4fmhWUtSxuUlkfz1ixT7j9wESokELzOg=
-k8s.io/apiextensions-apiserver v0.17.1 h1:Gw6zQgmKyyNrFMtVpRBNEKE8p35sDBI7Tq1ImxGS+zU=
 k8s.io/apiextensions-apiserver v0.17.1/go.mod h1:DRIFH5x3jalE4rE7JP0MQKby9zdYk9lUJQuMmp+M/L0=
 k8s.io/apiserver v0.17.1 h1:0cuh5kfAFPG2ImKT0rdNwdbPMUwDEfja14zX67V7eBQ=
 k8s.io/apiserver v0.17.1/go.mod h1:BQEUObJv8H6ZYO7DeKI5vb50tjk6paRJ4ZhSyJsiSco=

--- a/go.sum
+++ b/go.sum
@@ -348,6 +348,7 @@ github.com/cznic/ql v1.2.0/go.mod h1:FbpzhyZrqr0PVlK6ury+PoW3T0ODUV22OeWIxcaOrSE
 github.com/cznic/sortutil v0.0.0-20150617083342-4c7342852e65/go.mod h1:q2w6Bg5jeox1B+QkJ6Wp/+Vn0G/bo3f1uY7Fn3vivIQ=
 github.com/cznic/strutil v0.0.0-20171016134553-529a34b1c186/go.mod h1:AHHPPPXTw0h6pVabbcbyGRK1DckRn7r/STdZEeIDzZc=
 github.com/cznic/zappy v0.0.0-20160723133515-2533cb5b45cc/go.mod h1:Y1SNZ4dRUOKXshKUbwUapqNncRrho4mkjQebgEHZLj8=
+github.com/danieljoos/wincred v1.0.2/go.mod h1:SnuYRW9lp1oJrZX/dXJqr0cPK5gYXqx3EJbmjhLdK9U=
 github.com/davecgh/go-spew v0.0.0-20151105211317-5215b55f46b2/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
@@ -1352,6 +1353,8 @@ github.com/yvasiyarov/go-metrics v0.0.0-20150112132944-c25f46c4b940/go.mod h1:aX
 github.com/yvasiyarov/gorelic v0.0.0-20141212073537-a9bba5b9ab50/go.mod h1:NUSPSUX/bi6SeDMUh6brw0nXpxHnc96TguQh0+r/ssA=
 github.com/yvasiyarov/gorelic v0.0.6/go.mod h1:NUSPSUX/bi6SeDMUh6brw0nXpxHnc96TguQh0+r/ssA=
 github.com/yvasiyarov/newrelic_platform_go v0.0.0-20140908184405-b21fdbd4370f/go.mod h1:GlGEuHIJweS1mbCqG+7vt2nvWLzLLnRHbXz5JKd/Qbg=
+github.com/zalando/go-keyring v0.1.0 h1:ffq972Aoa4iHNzBlUHgK5Y+k8+r/8GvcGd80/OFZb/k=
+github.com/zalando/go-keyring v0.1.0/go.mod h1:RaxNwUITJaHVdQ0VC7pELPZ3tOWn13nr0gZMZEhpVU0=
 gitlab.com/nyarla/go-crypt v0.0.0-20160106005555-d9a5dc2b789b/go.mod h1:T3BPAOm2cqquPa0MKWeNkmOM5RQsRhkrwMWonFMN7fE=
 go.etcd.io/bbolt v1.3.1-etcd.7/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=

--- a/go.sum
+++ b/go.sum
@@ -348,6 +348,7 @@ github.com/cznic/ql v1.2.0/go.mod h1:FbpzhyZrqr0PVlK6ury+PoW3T0ODUV22OeWIxcaOrSE
 github.com/cznic/sortutil v0.0.0-20150617083342-4c7342852e65/go.mod h1:q2w6Bg5jeox1B+QkJ6Wp/+Vn0G/bo3f1uY7Fn3vivIQ=
 github.com/cznic/strutil v0.0.0-20171016134553-529a34b1c186/go.mod h1:AHHPPPXTw0h6pVabbcbyGRK1DckRn7r/STdZEeIDzZc=
 github.com/cznic/zappy v0.0.0-20160723133515-2533cb5b45cc/go.mod h1:Y1SNZ4dRUOKXshKUbwUapqNncRrho4mkjQebgEHZLj8=
+github.com/danieljoos/wincred v1.0.2 h1:zf4bhty2iLuwgjgpraD2E9UbvO+fe54XXGJbOwe23fU=
 github.com/danieljoos/wincred v1.0.2/go.mod h1:SnuYRW9lp1oJrZX/dXJqr0cPK5gYXqx3EJbmjhLdK9U=
 github.com/davecgh/go-spew v0.0.0-20151105211317-5215b55f46b2/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -547,6 +548,7 @@ github.com/gobuffalo/flect v0.1.5/go.mod h1:W3K3X9ksuZfir8f/LrfVtWmCDQFfayuylOJ7
 github.com/gobwas/glob v0.2.3/go.mod h1:d3Ez4x06l9bZtSvzIay5+Yzi0fmZzPgnTbPcKjJAkT8=
 github.com/gocql/gocql v0.0.0-20190301043612-f6df8288f9b4/go.mod h1:4Fw1eo5iaEhDUs8XyuhSVCVy52Jq3L+/3GJgYkwc+/0=
 github.com/godbus/dbus v0.0.0-20190422162347-ade71ed3457e/go.mod h1:bBOAhwG1umN6/6ZUMtDFBMQR8jRg9O75tm9K00oMsK4=
+github.com/godbus/dbus v4.1.0+incompatible h1:WqqLRTsQic3apZUK9qC5sGNfXthmPXzUZ7nQPrNITa4=
 github.com/godbus/dbus v4.1.0+incompatible/go.mod h1:/YcGZj5zSblfDWMMoOzV4fas9FZnQYTkDnsGvmh2Grw=
 github.com/gofrs/flock v0.0.0-20190320160742-5135e617513b/go.mod h1:F1TvTiK9OcQqauNUHlbJvyl9Qa1QvF/gOUDKA14jxHU=
 github.com/gofrs/flock v0.7.1/go.mod h1:F1TvTiK9OcQqauNUHlbJvyl9Qa1QvF/gOUDKA14jxHU=
@@ -805,7 +807,6 @@ github.com/jenkins-x/go-scm v1.5.79/go.mod h1:PCT338UhP/pQ0IeEeMEf/hoLTYKcH7qjGE
 github.com/jenkins-x/go-scm v1.5.117/go.mod h1:PCT338UhP/pQ0IeEeMEf/hoLTYKcH7qjGEKd7jPkeYg=
 github.com/jenkins-x/go-scm v1.5.160 h1:1OixAnfXn+3Ymxq3suALpJq7PilmpxKl62S6mO/woXM=
 github.com/jenkins-x/go-scm v1.5.160/go.mod h1:wJgj7PfgsCs+YAXC0vEj43g48HKf94apSyza62ADxKY=
-github.com/jenkins-x/go-scm v1.5.190 h1:fJKQJmn+WsIcojwFQEorpb7JXFxVJeaYY8y+4lbyweU=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/jimstudt/http-authentication v0.0.0-20140401203705-3eca13d6893a/go.mod h1:wK6yTYYcgjHE1Z1QtXACPDjcFJyBskHEdagmnq3vsP8=
 github.com/jingyugao/rowserrcheck v0.0.0-20191204022205-72ab7603b68a/go.mod h1:xRskid8CManxVta/ALEhJha/pweKBaVG6fWgc0yH25s=
@@ -1261,6 +1262,7 @@ github.com/streadway/amqp v0.0.0-20190404075320-75d898a42a94/go.mod h1:AZpEONHx3
 github.com/streadway/quantile v0.0.0-20150917103942-b0c588724d25/go.mod h1:lbP8tGiBjZ5YWIc2fzuRpTaz0b/53vT6PEs3QuAWzuU=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.2.0 h1:Hbg2NidpLE8veEBkEZTL3CvlkUIVzuU9jDplZO54c48=
 github.com/stretchr/objx v0.2.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoHMkEqE=
 github.com/stretchr/testify v0.0.0-20151208002404-e3a8ff8ce365/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=

--- a/pkg/cmd/bootstrap.go
+++ b/pkg/cmd/bootstrap.go
@@ -129,10 +129,6 @@ func nonInteractiveMode(io *BootstrapParameters, client *utility.Client) error {
 		return err
 	}
 	io.GitHostAccessToken = secret
-	err = ui.ValidateAccessToken(io.GitHostAccessToken, io.ServiceRepoURL)
-	if err != nil {
-		return fmt.Errorf("Please enter a valid access token: %v", err)
-	}
 	return nil
 }
 

--- a/pkg/cmd/bootstrap.go
+++ b/pkg/cmd/bootstrap.go
@@ -191,7 +191,7 @@ func initiateInteractiveMode(io *BootstrapParameters, client *utility.Client) er
 		identifier := factory.NewDriverIdentifier(factory.Mapping(host, io.PrivateRepoDriver))
 		factory.DefaultIdentifier = identifier
 	}
-	if ui.SelectOptionImageRepository() {
+	if ui.UseInternalRegistry() {
 		io.InternalRegistryHostname = ui.EnterInternalRegistry()
 		io.ImageRepo = ui.EnterImageRepoInternalRegistry()
 	} else {
@@ -204,7 +204,7 @@ func initiateInteractiveMode(io *BootstrapParameters, client *utility.Client) er
 		io.GitHostAccessToken = ui.EnterGitHostAccessToken(io.ServiceRepoURL)
 	}
 	io.ServiceWebhookSecret = ui.EnterServiceWebhookSecret()
-	if ui.SelectOptionAccessToken() {
+	if ui.UsePersonalAccessToken() {
 		io.GitHostAccessToken = ui.EnterGitHostAccessToken(io.ServiceRepoURL)
 		if io.GitHostAccessToken != "" {
 			err := setSecretIfNotSet(io.GitOpsRepoURL, io.GitHostAccessToken)
@@ -215,7 +215,7 @@ func initiateInteractiveMode(io *BootstrapParameters, client *utility.Client) er
 			if err != nil {
 				return err
 			}
-			io.CommitStatusTracker = ui.SelectOptionCommitStatusTracker()
+			io.CommitStatusTracker = ui.SetupCommitStatusTracker()
 			io.PushToGit = ui.SelectOptionPushToGit()
 		}
 	}

--- a/pkg/cmd/bootstrap.go
+++ b/pkg/cmd/bootstrap.go
@@ -150,7 +150,7 @@ func setSecretIfNotSet(repoURL, accessToken string) error {
 	if accessToken != secret {
 		err := keyring.Set("kam", hostName, accessToken)
 		if err != nil {
-			return fmt.Errorf("Unable to set access Token to keyring for repo: %q", repoURL)
+			return fmt.Errorf("unable to set access token for repo %q using keyring: %w", repoURL, err)
 		}
 	}
 	return nil

--- a/pkg/cmd/bootstrap.go
+++ b/pkg/cmd/bootstrap.go
@@ -188,15 +188,13 @@ func initiateInteractiveMode(io *BootstrapParameters, client *utility.Client) er
 	}
 	if err == nil && secret == "" {
 		io.GitHostAccessToken = ui.EnterGitHostAccessToken(io.ServiceRepoURL)
-		if io.GitHostAccessToken != "" {
-			err := webhook.SetSecret(io.GitOpsRepoURL, io.GitHostAccessToken)
-			if err != nil {
-				return err
-			}
-			err = webhook.SetSecret(io.ServiceRepoURL, io.GitHostAccessToken)
-			if err != nil {
-				return err
-			}
+		err := webhook.SetSecret(io.GitOpsRepoURL, io.GitHostAccessToken)
+		if err != nil {
+			return err
+		}
+		err = webhook.SetSecret(io.ServiceRepoURL, io.GitHostAccessToken)
+		if err != nil {
+			return err
 		}
 	} else {
 		io.GitHostAccessToken = secret

--- a/pkg/cmd/bootstrap.go
+++ b/pkg/cmd/bootstrap.go
@@ -124,10 +124,11 @@ func nonInteractiveMode(io *BootstrapParameters, client *utility.Client) error {
 	if err := checkMandatoryFlags(mandatoryFlags); err != nil {
 		return err
 	}
-	err := checkGitAccessToken(io)
+	secret, err := accesstoken.CheckGitAccessToken(io.GitHostAccessToken, io.ServiceRepoURL)
 	if err != nil {
 		return err
 	}
+	io.GitHostAccessToken = secret
 	err = ui.ValidateAccessToken(io.GitHostAccessToken, io.ServiceRepoURL)
 	if err != nil {
 		return fmt.Errorf("Please enter a valid access token: %v", err)
@@ -340,27 +341,4 @@ func isKnownDriver(repoURL string) bool {
 	}
 	_, err = factory.DefaultIdentifier.Identify(host)
 	return err == nil
-}
-
-func checkGitAccessToken(io *BootstrapParameters) error {
-	if io.GitHostAccessToken != "" {
-		err := accesstoken.SetSecret(io.GitOpsRepoURL, io.GitHostAccessToken)
-		if err != nil {
-			return err
-		}
-		err = accesstoken.SetSecret(io.ServiceRepoURL, io.GitHostAccessToken)
-		if err != nil {
-			return err
-		}
-	} else {
-		secret, err := accesstoken.GetAccessToken(io.ServiceRepoURL)
-		if err != nil {
-			return err
-		}
-		if secret == "" && err == nil {
-			return errors.New("unable to retrieve the access token from the keyring/env-var: kindly pass the --git-host-access-token")
-		}
-		io.GitHostAccessToken = secret
-	}
-	return nil
 }

--- a/pkg/cmd/bootstrap.go
+++ b/pkg/cmd/bootstrap.go
@@ -332,7 +332,7 @@ func NewCmdBootstrap(name, fullName string) *cobra.Command {
 	bootstrapCmd.Flags().StringVar(&o.ServiceRepoURL, "service-repo-url", "", "Provide the URL for your Service repository e.g. https://github.com/organisation/service.git")
 	bootstrapCmd.Flags().StringVar(&o.ServiceWebhookSecret, "service-webhook-secret", "", "Provide a secret that we can use to authenticate incoming hooks from your Git hosting service for the Service repository. (if not provided, it will be auto-generated)")
 	bootstrapCmd.Flags().StringVar(&o.PrivateRepoDriver, "private-repo-driver", "", "If your Git repositories are on a custom domain, please indicate which driver to use github or gitlab")
-	bootstrapCmd.Flags().BoolVar(&o.CommitStatusTracker, "commit-status-tracker", true, "Enable or disable the commit-status-tracker which reports the success/failure of your pipelineruns to GitHub/GitLab")
+	bootstrapCmd.Flags().BoolVar(&o.CommitStatusTracker, "commit-status-tracker",false, "Enable or disable the commit-status-tracker which reports the success/failure of your pipelineruns to GitHub/GitLab")
 	bootstrapCmd.Flags().BoolVar(&o.PushToGit, "push-to-git", false, "If true, automatically creates and populates the gitops-repo-url with the generated resources")
 	return bootstrapCmd
 }

--- a/pkg/cmd/bootstrap.go
+++ b/pkg/cmd/bootstrap.go
@@ -320,7 +320,7 @@ func NewCmdBootstrap(name, fullName string) *cobra.Command {
 	bootstrapCmd.Flags().StringVar(&o.ImageRepo, "image-repo", "", "Image repository of the form <registry>/<username>/<repository> or <project>/<app> which is used to push newly built images")
 	bootstrapCmd.Flags().StringVar(&o.SealedSecretsService.Namespace, "sealed-secrets-ns", secrets.SealedSecretsNS, "Namespace in which the Sealed Secrets operator is installed, automatically generated secrets are encrypted with this operator")
 	bootstrapCmd.Flags().StringVar(&o.SealedSecretsService.Name, "sealed-secrets-svc", secrets.SealedSecretsController, "Name of the Sealed Secrets Services that encrypts secrets")
-	bootstrapCmd.Flags().StringVar(&o.GitHostAccessToken, statustracker.CommitStatusTrackerSecret, "", "Used to authenticate repository clones, and commit-status notifications (if enabled)")
+	bootstrapCmd.Flags().StringVar(&o.GitHostAccessToken, statustracker.CommitStatusTrackerSecret, "", "Used to authenticate repository clones, and commit-status notifications (if enabled). Will update the token in the keyring if present.")
 	bootstrapCmd.Flags().BoolVar(&o.Overwrite, "overwrite", false, "Overwrites previously existing GitOps configuration (if any)")
 	bootstrapCmd.Flags().StringVar(&o.ServiceRepoURL, "service-repo-url", "", "Provide the URL for your Service repository e.g. https://github.com/organisation/service.git")
 	bootstrapCmd.Flags().StringVar(&o.ServiceWebhookSecret, "service-webhook-secret", "", "Provide a secret that we can use to authenticate incoming hooks from your Git hosting service for the Service repository. (if not provided, it will be auto-generated)")

--- a/pkg/cmd/bootstrap.go
+++ b/pkg/cmd/bootstrap.go
@@ -338,7 +338,7 @@ func NewCmdBootstrap(name, fullName string) *cobra.Command {
 	bootstrapCmd.Flags().BoolVar(&o.Overwrite, "overwrite", false, "Overwrites previously existing GitOps configuration (if any)")
 	bootstrapCmd.Flags().StringVar(&o.ServiceRepoURL, "service-repo-url", "", "Provide the URL for your Service repository e.g. https://github.com/organisation/service.git")
 	bootstrapCmd.Flags().StringVar(&o.ServiceWebhookSecret, "service-webhook-secret", "", "Provide a secret that we can use to authenticate incoming hooks from your Git hosting service for the Service repository. (if not provided, it will be auto-generated)")
-	bootstrapCmd.Flags().BoolVar(&o.SaveTokenKeyRing, "save-token-keyring", false, "Explicitely pass this flag to update the git-host-access-token in the keyring on your local file system")
+	bootstrapCmd.Flags().BoolVar(&o.SaveTokenKeyRing, "SaveTokenKeyring", false, "Explicitely pass this flag to update the git-host-access-token in the keyring on your local file system")
 	bootstrapCmd.Flags().StringVar(&o.PrivateRepoDriver, "private-repo-driver", "", "If your Git repositories are on a custom domain, please indicate which driver to use github or gitlab")
 	bootstrapCmd.Flags().BoolVar(&o.CommitStatusTracker, "commit-status-tracker", true, "Enable or disable the commit-status-tracker which reports the success/failure of your pipelineruns to GitHub/GitLab")
 	bootstrapCmd.Flags().BoolVar(&o.PushToGit, "push-to-git", false, "If true, automatically creates and populates the gitops-repo-url with the generated resources")

--- a/pkg/cmd/bootstrap.go
+++ b/pkg/cmd/bootstrap.go
@@ -320,7 +320,7 @@ func NewCmdBootstrap(name, fullName string) *cobra.Command {
 	bootstrapCmd.Flags().StringVar(&o.ImageRepo, "image-repo", "", "Image repository of the form <registry>/<username>/<repository> or <project>/<app> which is used to push newly built images")
 	bootstrapCmd.Flags().StringVar(&o.SealedSecretsService.Namespace, "sealed-secrets-ns", secrets.SealedSecretsNS, "Namespace in which the Sealed Secrets operator is installed, automatically generated secrets are encrypted with this operator")
 	bootstrapCmd.Flags().StringVar(&o.SealedSecretsService.Name, "sealed-secrets-svc", secrets.SealedSecretsController, "Name of the Sealed Secrets Services that encrypts secrets")
-	bootstrapCmd.Flags().StringVar(&o.GitHostAccessToken, statustracker.CommitStatusTrackerSecret, "", "Used to authenticate repository clones, and commit-status notifications (if enabled). Will update the token in the keyring if present.")
+	bootstrapCmd.Flags().StringVar(&o.GitHostAccessToken, statustracker.CommitStatusTrackerSecret, "", "Used to authenticate repository clones, and commit-status notifications (if enabled). Access token will be updated in the keyring")
 	bootstrapCmd.Flags().BoolVar(&o.Overwrite, "overwrite", false, "Overwrites previously existing GitOps configuration (if any)")
 	bootstrapCmd.Flags().StringVar(&o.ServiceRepoURL, "service-repo-url", "", "Provide the URL for your Service repository e.g. https://github.com/organisation/service.git")
 	bootstrapCmd.Flags().StringVar(&o.ServiceWebhookSecret, "service-webhook-secret", "", "Provide a secret that we can use to authenticate incoming hooks from your Git hosting service for the Service repository. (if not provided, it will be auto-generated)")

--- a/pkg/cmd/bootstrap_test.go
+++ b/pkg/cmd/bootstrap_test.go
@@ -223,14 +223,8 @@ func TestKeyRingSet(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Non Interactive mode failed with error: %v", err)
 		}
-		gitopsToken, err := keyring.Get("kam", tt.gitRepo)
-		if err != nil {
-			t.Fatal(err)
-		}
-		serviceToken, err := keyring.Get("kam", tt.serviceRepo)
-		if err != nil {
-			t.Fatal(err)
-		}
+		gitopsToken, _ := keyring.Get("kam", tt.gitRepo)
+		serviceToken, _ := keyring.Get("kam", tt.serviceRepo)
 		if tt.expectedToken != gitopsToken && tt.expectedToken != serviceToken {
 			t.Fatalf("TestKeyRingSet() Failed since expected token %v did not match %v", tt.expectedToken, gitopsToken)
 		}

--- a/pkg/cmd/bootstrap_test.go
+++ b/pkg/cmd/bootstrap_test.go
@@ -203,11 +203,14 @@ func TestKeyRingSet(t *testing.T) {
 		serviceRepo   string
 		imagerepo     string
 		gitToken      string
+		expectedKey   string
 		expectedToken string
 	}{
-		{"exclude gitToken to execute as exepected", "https://github.com/example/gitRepo.git", "https://github.com/example/serviceRepo.git", "registry/username/repo", "", ""},
-		{"add git accessToken", "https://github.com/example/gitRepo.git", "https://github.com/example/service.git", "registry/username/repo", "abc123", "abc123"},
-		{"overwrite gitops repo access token", "https://github.com/example/gitRepo.git", "https://github.com/example/service.git", "registry/username/repo", "xyz123", "xyz123"},
+		{"exclude gitToken to execute as exepected", "https://github.com/example/gitRepo.git", "https://github.com/example/serviceRepo.git", "registry/username/repo", "", "github.com", ""},
+		{"set the github access token in keyring", "https://github.com/example/gitRepo.git", "https://github.com/example/service.git", "registry/username/repo", "abc123", "github.com", "abc123"},
+		{"overwrite github access token in keyring", "https://github.com/example/gitRepo.git", "https://github.com/example/service.git", "registry/username/repo", "xyz123", "github.com", "xyz123"},
+		{"set the gitlab access Token in keyring", "https://gitlab.com/example/gitRepo.git", "https://gitlan.com/example/service.git", "registry/username/repo", "test123", "gitlab.com", "test123"},
+		{"overwrite gitlab access token in keyring", "https://gitlab.com/example/gitRepo.git", "https://gitlab.com/example/service.git", "registry/username/repo", "test345", "gitlab.com", "test345"},
 	}
 
 	for _, tt := range optionTests {
@@ -223,8 +226,8 @@ func TestKeyRingSet(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Non Interactive mode failed with error: %v", err)
 		}
-		gitopsToken, _ := keyring.Get("kam", tt.gitRepo)
-		serviceToken, _ := keyring.Get("kam", tt.serviceRepo)
+		gitopsToken, _ := keyring.Get("kam", tt.expectedKey)
+		serviceToken, _ := keyring.Get("kam", tt.expectedKey)
 		if tt.expectedToken != gitopsToken && tt.expectedToken != serviceToken {
 			t.Fatalf("TestKeyRingSet() Failed since expected token %v did not match %v", tt.expectedToken, gitopsToken)
 		}

--- a/pkg/cmd/bootstrap_test.go
+++ b/pkg/cmd/bootstrap_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/redhat-developer/kam/pkg/cmd/utility"
 	"github.com/redhat-developer/kam/pkg/pipelines"
 	"github.com/redhat-developer/kam/pkg/pipelines/secrets"
+	"github.com/redhat-developer/kam/pkg/pipelines/webhook"
 	"github.com/zalando/go-keyring"
 	appv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -226,8 +227,8 @@ func TestKeyRingSet(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Non Interactive mode failed with error: %v", err)
 		}
-		gitopsToken, _ := keyring.Get("kam", tt.expectedKey)
-		serviceToken, _ := keyring.Get("kam", tt.expectedKey)
+		gitopsToken, _ := keyring.Get(webhook.KeyringServiceName, tt.expectedKey)
+		serviceToken, _ := keyring.Get(webhook.KeyringServiceName, tt.expectedKey)
 		if tt.expectedToken != gitopsToken && tt.expectedToken != serviceToken {
 			t.Fatalf("TestKeyRingSet() Failed since expected token %v did not match %v", tt.expectedToken, gitopsToken)
 		}

--- a/pkg/cmd/bootstrap_test.go
+++ b/pkg/cmd/bootstrap_test.go
@@ -6,8 +6,9 @@ import (
 	"io"
 	"os"
 	"regexp"
-	"strings"
 	"testing"
+
+	"github.com/redhat-developer/kam/pkg/pipelines/accesstoken"
 
 	"k8s.io/apimachinery/pkg/runtime"
 
@@ -17,7 +18,6 @@ import (
 	"github.com/redhat-developer/kam/pkg/cmd/utility"
 	"github.com/redhat-developer/kam/pkg/pipelines"
 	"github.com/redhat-developer/kam/pkg/pipelines/secrets"
-	"github.com/redhat-developer/kam/pkg/pipelines/webhook"
 	"github.com/zalando/go-keyring"
 	appv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -228,8 +228,8 @@ func TestKeyRingFlagSet(t *testing.T) {
 		if err != nil {
 			t.Errorf("checkGitAccessToken() mode failed with error: %v", err)
 		}
-		gitopsToken, _ := keyring.Get(webhook.KeyringServiceName, tt.expectedKey)
-		serviceToken, _ := keyring.Get(webhook.KeyringServiceName, tt.expectedKey)
+		gitopsToken, _ := keyring.Get(accesstoken.KeyringServiceName, tt.expectedKey)
+		serviceToken, _ := keyring.Get(accesstoken.KeyringServiceName, tt.expectedKey)
 		if tt.expectedToken != gitopsToken && tt.expectedToken != serviceToken {
 			t.Errorf("TestKeyRingFlagSet() Failed since expected token %v did not match %v", tt.expectedToken, gitopsToken)
 		}
@@ -256,12 +256,11 @@ func TestKeyRingFlagNotSet(t *testing.T) {
 
 	for i, tt := range optionTests {
 		t.Run(fmt.Sprintf("Test %d", i), func(t *testing.T) {
-			hostName, err := webhook.HostFromURL(tt.gitRepo)
+			hostName, err := accesstoken.HostFromURL(tt.gitRepo)
 			if err != nil {
 				t.Error("Failed to get host name from access token")
 			}
-			h := strings.ReplaceAll(hostName, ".", "_")
-			envVar := strings.ToUpper(h) + "_TOKEN"
+			envVar := accesstoken.GetEnvVarName(hostName)
 			defer os.Unsetenv(envVar)
 			if tt.envVarPresent {
 				err := os.Setenv(envVar, "abc123")

--- a/pkg/cmd/bootstrap_test.go
+++ b/pkg/cmd/bootstrap_test.go
@@ -29,6 +29,11 @@ type mockSpinner struct {
 	end    bool
 }
 
+const (
+	gitOpsURL  = "https://github.com/org/gitops"
+	serviceURL = "https://github.com/org/app"
+)
+
 func TestValidatePrefix(t *testing.T) {
 	completeTests := []struct {
 		name        string
@@ -62,8 +67,6 @@ func TestValidatePrefix(t *testing.T) {
 }
 
 func TestAddSuffixWithBootstrap(t *testing.T) {
-	gitOpsURL := "https://github.com/org/gitops"
-	appURL := "https://github.com/org/app"
 	tt := []struct {
 		name           string
 		gitOpsURL      string
@@ -71,8 +74,8 @@ func TestAddSuffixWithBootstrap(t *testing.T) {
 		validGitOpsURL string
 		validAppURL    string
 	}{
-		{"suffix already exists", gitOpsURL + ".git", appURL + ".git", gitOpsURL + ".git", appURL + ".git"},
-		{"misssing suffix", gitOpsURL, appURL, gitOpsURL + ".git", appURL + ".git"},
+		{"suffix already exists", gitOpsURL + ".git", serviceURL + ".git", gitOpsURL + ".git", serviceURL + ".git"},
+		{"misssing suffix", gitOpsURL, serviceURL, gitOpsURL + ".git", serviceURL + ".git"},
 	}
 
 	for _, test := range tt {
@@ -149,6 +152,44 @@ func TestValidateBootstrapParameter(t *testing.T) {
 				GitOpsRepoURL:     tt.gitRepo,
 				PrivateRepoDriver: tt.driver,
 				Prefix:            "test",
+			},
+		}
+		err := o.Validate()
+
+		if err != nil && tt.errMsg == "" {
+			t.Errorf("Validate() %#v got an unexpected error: %s", tt.name, err)
+			continue
+		}
+
+		if !matchError(t, tt.errMsg, err) {
+			t.Errorf("Validate() %#v failed to match error: got %s, want %s", tt.name, err, tt.errMsg)
+		}
+	}
+}
+
+func TestValidatePairFlags(t *testing.T) {
+	optionTests := []struct {
+		name          string
+		token         string
+		statustracker bool
+		keyring       bool
+		errMsg        string
+	}{
+		{"--save-token-keyring set and --git-host-access-token missing", "", false, true, "--git-host-access-token is required if --save-token-keyring is enabled"},
+		{"--commit-status-tracker set and --git-host-access-token missing", "", true, false, "--git-host-access-token is required if commit-status-tracker is enabled"},
+		{"--commit-status-tracker/--save-token-keyring set and --git-host-access-token present", "abc123", true, true, ""},
+		{"--commit-status-tracker/--save-token-keyring not-set and --git-host-access-token absent", "", false, false, ""},
+	}
+
+	for _, tt := range optionTests {
+		o := BootstrapParameters{
+			BootstrapOptions: &pipelines.BootstrapOptions{
+				GitOpsRepoURL:       gitOpsURL,
+				ServiceRepoURL:      serviceURL,
+				ImageRepo:           "io/test/repo",
+				GitHostAccessToken:  tt.token,
+				CommitStatusTracker: tt.statustracker,
+				SaveTokenKeyRing:    tt.keyring,
 			},
 		}
 		err := o.Validate()

--- a/pkg/cmd/ui/ui.go
+++ b/pkg/cmd/ui/ui.go
@@ -201,8 +201,8 @@ func EnterServiceWebhookSecret() string {
 	return serviceWebhookSecret
 }
 
-// SelectOptionImageRepository , allows users an option between the Internal image registry and the external image registry through the UI prompt.
-func SelectOptionImageRepository() bool {
+// UseInternalRegistry , allows users an option between the Internal image registry and the external image registry through the UI prompt.
+func UseInternalRegistry() bool {
 	var optionImageRegistry string
 	prompt := &survey.Select{
 		Message: "Select type of image registry",
@@ -228,9 +228,9 @@ func SelectOptionOverwrite(path string) string {
 	return overwrite
 }
 
-// SelectOptionCommitStatusTracker allows users the option to select if they
+// SetupCommitStatusTracker allows users the option to select if they
 // want to incorporate the feature of the commit status tracker through the UI prompt.
-func SelectOptionCommitStatusTracker() bool {
+func SetupCommitStatusTracker() bool {
 	var optionCommitStatusTracker string
 	prompt := &survey.Select{
 		Message: "Do you want to enable commit-status-tracker?",
@@ -283,8 +283,8 @@ func SelectOptionPushToGit() bool {
 	return optionPushToGit == "yes"
 }
 
-// SelectOptionAccessToken allows users the option to pass the access token to set up automated pushes and also commit-status-tracker
-func SelectOptionAccessToken() bool{
+// UsePersonalAccessToken allows users the option to pass the access token to set up automated pushes and also commit-status-tracker
+func UsePersonalAccessToken() bool {
 	var tokenOption string
 	prompt := &survey.Select{
 		Message: "Do you possess a git personal access token?",

--- a/pkg/cmd/ui/ui.go
+++ b/pkg/cmd/ui/ui.go
@@ -151,7 +151,7 @@ func EnterGitHostAccessToken(serviceRepo string) string {
 	var accessToken string
 	prompt := &survey.Password{
 		Message: fmt.Sprintf("Please provide a token used to authenticate requests to %q", serviceRepo),
-		Help:    "commit-status-tracker reports the completion status of OpenShift pipeline runs to your Git hosting status on success or failure, this token will be encrypted as a secret in your cluster.\nIf you are using Github, please see here for how to generate a token https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token\nIf you are using GitLab, please see here for how to generate a token https://docs.gitlab.com/ee/user/profile/personal_access_tokens.html",
+		Help:    "Tokens are required to enable commit status tracker (completion status of OpenShift pipeline on your version control system UI) and automated creation/push of gitops resources, this token will be encrypted as a secret in your cluster.\nIf you are using Github, please see here for how to generate a token https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token\nIf you are using GitLab, please see here for how to generate a token https://docs.gitlab.com/ee/user/profile/personal_access_tokens.html",
 	}
 	err := survey.AskOne(prompt, &accessToken, makeAccessTokenCheck(serviceRepo))
 	handleError(err)

--- a/pkg/cmd/ui/ui.go
+++ b/pkg/cmd/ui/ui.go
@@ -288,7 +288,7 @@ func SelectOptionAccessToken() bool{
 	var tokenOption string
 	prompt := &survey.Select{
 		Message: "Do you possess a git personal access token?",
-		Help:    "To create an Access token follow this link https://github.com/settings/tokens/new?scopes=repo, required for commit status tracker/automated create and push to git Repo",
+		Help:    "How to create a token? follow this link for github[https://docs.github.com/en/free-pro-team@latest/github/authenticating-to-github/creating-a-personal-access-token]/gitlab[https://docs.gitlab.com/ee/user/profile/personal_access_tokens.html], token is required for commit status tracker/automated create and push to git Repo",
 		Options: []string{"yes", "no"},
 	}
 	err := survey.AskOne(prompt, &tokenOption, survey.Required)

--- a/pkg/cmd/ui/ui.go
+++ b/pkg/cmd/ui/ui.go
@@ -202,7 +202,7 @@ func EnterServiceWebhookSecret() string {
 }
 
 // SelectOptionImageRepository , allows users an option between the Internal image registry and the external image registry through the UI prompt.
-func SelectOptionImageRepository() string {
+func SelectOptionImageRepository() bool {
 	var optionImageRegistry string
 	prompt := &survey.Select{
 		Message: "Select type of image registry",
@@ -212,7 +212,7 @@ func SelectOptionImageRepository() string {
 
 	err := survey.AskOne(prompt, &optionImageRegistry, survey.Required)
 	handleError(err)
-	return optionImageRegistry
+	return optionImageRegistry == "Openshift Internal registry"
 }
 
 // SelectOptionOverwrite allows users the option to overwrite the current gitops configuration locally through the UI prompt.
@@ -230,7 +230,7 @@ func SelectOptionOverwrite(path string) string {
 
 // SelectOptionCommitStatusTracker allows users the option to select if they
 // want to incorporate the feature of the commit status tracker through the UI prompt.
-func SelectOptionCommitStatusTracker() string {
+func SelectOptionCommitStatusTracker() bool {
 	var optionCommitStatusTracker string
 	prompt := &survey.Select{
 		Message: "Do you want to enable commit-status-tracker?",
@@ -239,7 +239,7 @@ func SelectOptionCommitStatusTracker() string {
 	}
 	err := survey.AskOne(prompt, &optionCommitStatusTracker, survey.Required)
 	handleError(err)
-	return optionCommitStatusTracker
+	return optionCommitStatusTracker == "yes"
 }
 
 // SelectPrivateRepoDriver lets users choose the driver for their git hosting
@@ -281,4 +281,17 @@ func SelectOptionPushToGit() bool {
 	err := survey.AskOne(prompt, &optionPushToGit, survey.Required)
 	handleError(err)
 	return optionPushToGit == "yes"
+}
+
+// SelectOptionAccessToken allows users the option to pass the access token to set up automated pushes and also commit-status-tracker
+func SelectOptionAccessToken() bool{
+	var tokenOption string
+	prompt := &survey.Select{
+		Message: "Do you possess a git personal access token?",
+		Help:    "To create an Access token follow this link https://github.com/settings/tokens/new?scopes=repo, required for commit status tracker/automated create and push to git Repo",
+		Options: []string{"yes", "no"},
+	}
+	err := survey.AskOne(prompt, &tokenOption, survey.Required)
+	handleError(err)
+	return tokenOption == "yes"
 }

--- a/pkg/cmd/ui/ui.go
+++ b/pkg/cmd/ui/ui.go
@@ -269,3 +269,17 @@ func SelectOptionPushToGit() bool {
 	handleError(err)
 	return optionPushToGit == "yes"
 }
+
+// UseKeyringRingSvc , allows users an option between the Internal image registry and the external image registry through the UI prompt.
+func UseKeyringRingSvc() bool {
+	var optionImageRegistry string
+	prompt := &survey.Select{
+		Message: "Do you wish to securely store the git-host-access-token in the keyring on your local machine?",
+		Help:    "The token will be stored securely in the keyring of your local mahine. It will be reused by kam commands(bootstrap/webhoook), further iteration of these commands will not prompt for the access-token",
+		Options: []string{"Yes", "No"},
+	}
+
+	err := survey.AskOne(prompt, &optionImageRegistry, survey.Required)
+	handleError(err)
+	return optionImageRegistry == "Yes"
+}

--- a/pkg/cmd/ui/ui.go
+++ b/pkg/cmd/ui/ui.go
@@ -108,10 +108,10 @@ func EnterOutputPath() string {
 
 // EnterGitWebhookSecret allows the user to specify the webhook secret string
 // they wish to authenticate push/pull to GitOps repo in a UI prompt.
-func EnterGitWebhookSecret() string {
+func EnterGitWebhookSecret(repoURL string) string {
 	var gitWebhookSecret string
-	prompt := &survey.Input{
-		Message: "Provide a secret (minimum 16 characters) that we can use to authenticate incoming hooks from your Git hosting service for the Service repository. (if not provided, it will be auto-generated)",
+	prompt := &survey.Password{
+		Message: fmt.Sprintf("Provide a secret (minimum 16 characters) that we can use to authenticate incoming hooks from your Git hosting service for repository: %s. (if not provided, it will be auto-generated)", repoURL),
 		Help:    "You can provide a string that is used as a shared secret to authenticate the origin of hook notifications from your git host.",
 	}
 
@@ -151,7 +151,7 @@ func EnterGitHostAccessToken(serviceRepo string) string {
 	var accessToken string
 	prompt := &survey.Password{
 		Message: fmt.Sprintf("Please provide a token used to authenticate requests to %q", serviceRepo),
-		Help:    "Tokens are required to enable commit status tracker (completion status of OpenShift pipeline on your version control system UI) and automated creation/push of gitops resources, this token will be encrypted as a secret in your cluster.\nIf you are using Github, please see here for how to generate a token https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token\nIf you are using GitLab, please see here for how to generate a token https://docs.gitlab.com/ee/user/profile/personal_access_tokens.html",
+		Help:    "Tokens are required to authenticate to git provider various operations on git repository (e.g. enable automated creation/push to git-repo).",
 	}
 	err := survey.AskOne(prompt, &accessToken, makeAccessTokenCheck(serviceRepo))
 	handleError(err)

--- a/pkg/cmd/ui/ui.go
+++ b/pkg/cmd/ui/ui.go
@@ -256,19 +256,6 @@ func SelectPrivateRepoDriver() string {
 	return driver
 }
 
-// IsPrivateRepo lets the user choose between a private / public repository.
-func IsPrivateRepo() bool {
-	var response string
-	prompt := &survey.Select{
-		Message: "Is this repository a private repository?",
-		Options: []string{"yes", "no"},
-	}
-
-	err := survey.AskOne(prompt, &response, survey.Required)
-	handleError(err)
-	return response == "yes"
-}
-
 // SelectOptionPushToGit allows users the option to select if they
 // want to incorporate the feature of the commit status tracker through the UI prompt.
 func SelectOptionPushToGit() bool {
@@ -281,17 +268,4 @@ func SelectOptionPushToGit() bool {
 	err := survey.AskOne(prompt, &optionPushToGit, survey.Required)
 	handleError(err)
 	return optionPushToGit == "yes"
-}
-
-// UsePersonalAccessToken allows users the option to pass the access token to set up automated pushes and also commit-status-tracker
-func UsePersonalAccessToken() bool {
-	var tokenOption string
-	prompt := &survey.Select{
-		Message: "Do you possess a git personal access token?",
-		Help:    "How to create a token? follow this link for github[https://docs.github.com/en/free-pro-team@latest/github/authenticating-to-github/creating-a-personal-access-token]/gitlab[https://docs.gitlab.com/ee/user/profile/personal_access_tokens.html], token is required for commit status tracker/automated create and push to git Repo",
-		Options: []string{"yes", "no"},
-	}
-	err := survey.AskOne(prompt, &tokenOption, survey.Required)
-	handleError(err)
-	return tokenOption == "yes"
 }

--- a/pkg/cmd/ui/validate.go
+++ b/pkg/cmd/ui/validate.go
@@ -47,7 +47,7 @@ func makeSealedSecretsService(sealedSecretService *types.NamespacedName) survey.
 
 func makeAccessTokenCheck(serviceRepo string) survey.Validator {
 	return func(input interface{}) error {
-		return validateAccessToken(input, serviceRepo)
+		return ValidateAccessToken(input, serviceRepo)
 	}
 }
 
@@ -108,8 +108,8 @@ func validateOverwriteOption(input interface{}, path string) error {
 
 }
 
-// validateAccessToken validates if the access token is correct for a particular service repo
-func validateAccessToken(input interface{}, serviceRepo string) error {
+// ValidateAccessToken validates if the access token is correct for a particular service repo
+func ValidateAccessToken(input interface{}, serviceRepo string) error {
 	if s, ok := input.(string); ok {
 		repo, err := git.NewRepository(serviceRepo, s)
 		if err != nil {

--- a/pkg/cmd/webhook/create_test.go
+++ b/pkg/cmd/webhook/create_test.go
@@ -14,32 +14,6 @@ type keyValuePair struct {
 	value string
 }
 
-func TestMissingRequiredFlagsForCreate(t *testing.T) {
-	testcases := []struct {
-		flags   []keyValuePair
-		wantErr string
-	}{
-		{[]keyValuePair{flag("cicd", "true")},
-			`required flag(s) "access-token" not set`,
-		},
-	}
-	for i, tt := range testcases {
-		t.Run(fmt.Sprintf("Test %d", i), func(rt *testing.T) {
-			_, err := executeCommand(newCmdCreate("webhook", "kam pipelines webhook create"), tt.flags...)
-
-			if err != nil {
-				if err.Error() != tt.wantErr {
-					rt.Errorf("got %s, want %s", err, tt.wantErr)
-				}
-			} else {
-				if tt.wantErr != "" {
-					rt.Errorf("got %s, want %s", "", tt.wantErr)
-				}
-			}
-		})
-	}
-}
-
 func TestValidateForCreate(t *testing.T) {
 	testcases := []struct {
 		options *createOptions

--- a/pkg/cmd/webhook/delete_test.go
+++ b/pkg/cmd/webhook/delete_test.go
@@ -5,33 +5,6 @@ import (
 	"testing"
 )
 
-func TestMissingRequiredFlagsForDelete(t *testing.T) {
-	testcases := []struct {
-		flags   []keyValuePair
-		wantErr string
-	}{
-		{[]keyValuePair{flag("cicd", "true")},
-			`required flag(s) "access-token" not set`,
-		},
-	}
-
-	for i, tt := range testcases {
-		t.Run(fmt.Sprintf("Test %d", i), func(rt *testing.T) {
-			_, err := executeCommand(newCmdDelete("webhook", "kam pipelines webhook delete"), tt.flags...)
-
-			if err != nil {
-				if err.Error() != tt.wantErr {
-					rt.Errorf("got %s, want %s", err, tt.wantErr)
-				}
-			} else {
-				if tt.wantErr != "" {
-					rt.Errorf("got %s, want %s", "", tt.wantErr)
-				}
-			}
-		})
-	}
-}
-
 func TestValidateForDelete(t *testing.T) {
 
 	testcases := []struct {

--- a/pkg/cmd/webhook/list_test.go
+++ b/pkg/cmd/webhook/list_test.go
@@ -5,33 +5,6 @@ import (
 	"testing"
 )
 
-func TestMissingRequiredFlagsForList(t *testing.T) {
-	testcases := []struct {
-		flags   []keyValuePair
-		wantErr string
-	}{
-		{[]keyValuePair{flag("cicd", "true")},
-			`required flag(s) "access-token" not set`,
-		},
-	}
-
-	for i, tt := range testcases {
-		t.Run(fmt.Sprintf("Test %d", i), func(rt *testing.T) {
-			_, err := executeCommand(newCmdList("webhook", "kam pipelines webhook create"), tt.flags...)
-
-			if err != nil {
-				if err.Error() != tt.wantErr {
-					rt.Errorf("got %s, want %s", err, tt.wantErr)
-				}
-			} else {
-				if tt.wantErr != "" {
-					rt.Errorf("got %s, want %s", "", tt.wantErr)
-				}
-			}
-		})
-	}
-}
-
 func TestValidateForList(t *testing.T) {
 	testcases := []struct {
 		options *listOptions

--- a/pkg/cmd/webhook/webhook_cmd.go
+++ b/pkg/cmd/webhook/webhook_cmd.go
@@ -46,7 +46,6 @@ func (o *options) setFlags(command *cobra.Command) {
 
 	// access-token option
 	command.Flags().StringVar(&o.accessToken, "access-token", "", "Access token to be used to create Git repository webhook")
-	// _ = command.MarkFlagRequired("access-token")
 
 	// cicd option
 	command.Flags().BoolVar(&o.isCICD, "cicd", false, "Provide this flag if the target Git repository is a CI/CD configuration repository")

--- a/pkg/cmd/webhook/webhook_cmd.go
+++ b/pkg/cmd/webhook/webhook_cmd.go
@@ -45,7 +45,7 @@ func (o *options) setFlags(command *cobra.Command) {
 	command.Flags().StringVar(&o.pipelinesFolderPath, "pipelines-folder", ".", "Folder path to retrieve manifest, eg. /test where manifest exists at /test/pipelines.yaml")
 
 	// access-token option
-	command.Flags().StringVar(&o.accessToken, "access-token", "", "Access token to be used to create Git repository webhook")
+	command.Flags().StringVar(&o.accessToken, "access-token", "", "Access token to be used to create Git repository webhook (will update the token in the keyring if present)")
 
 	// cicd option
 	command.Flags().BoolVar(&o.isCICD, "cicd", false, "Provide this flag if the target Git repository is a CI/CD configuration repository")

--- a/pkg/cmd/webhook/webhook_cmd.go
+++ b/pkg/cmd/webhook/webhook_cmd.go
@@ -45,7 +45,7 @@ func (o *options) setFlags(command *cobra.Command) {
 	command.Flags().StringVar(&o.pipelinesFolderPath, "pipelines-folder", ".", "Folder path to retrieve manifest, eg. /test where manifest exists at /test/pipelines.yaml")
 
 	// access-token option
-	command.Flags().StringVar(&o.accessToken, "access-token", "", "Access token to be used to create Git repository webhook. Access token is encrypted and stored on local file system by keyring, will be updated/reused.")
+	command.Flags().StringVar(&o.accessToken, "git-host-access-token", "", "Access token to be used to create Git repository webhook. Access token is encrypted and stored on local file system by keyring, will be updated/reused.")
 
 	// cicd option
 	command.Flags().BoolVar(&o.isCICD, "cicd", false, "Provide this flag if the target Git repository is a CI/CD configuration repository")
@@ -57,7 +57,6 @@ func (o *options) setFlags(command *cobra.Command) {
 }
 
 func (o *options) getAppServiceNames() *backend.QualifiedServiceName {
-
 	return &backend.QualifiedServiceName{
 		EnvironmentName: o.envName,
 		ServiceName:     o.serviceName,

--- a/pkg/cmd/webhook/webhook_cmd.go
+++ b/pkg/cmd/webhook/webhook_cmd.go
@@ -46,7 +46,7 @@ func (o *options) setFlags(command *cobra.Command) {
 
 	// access-token option
 	command.Flags().StringVar(&o.accessToken, "access-token", "", "Access token to be used to create Git repository webhook")
-	_ = command.MarkFlagRequired("access-token")
+	// _ = command.MarkFlagRequired("access-token")
 
 	// cicd option
 	command.Flags().BoolVar(&o.isCICD, "cicd", false, "Provide this flag if the target Git repository is a CI/CD configuration repository")

--- a/pkg/cmd/webhook/webhook_cmd.go
+++ b/pkg/cmd/webhook/webhook_cmd.go
@@ -45,7 +45,7 @@ func (o *options) setFlags(command *cobra.Command) {
 	command.Flags().StringVar(&o.pipelinesFolderPath, "pipelines-folder", ".", "Folder path to retrieve manifest, eg. /test where manifest exists at /test/pipelines.yaml")
 
 	// access-token option
-	command.Flags().StringVar(&o.accessToken, "access-token", "", "Access token to be used to create Git repository webhook. Access token will be updated in the keyring")
+	command.Flags().StringVar(&o.accessToken, "access-token", "", "Access token to be used to create Git repository webhook. Access token is encrypted and stored on local file system by keyring, will be updated/reused.")
 
 	// cicd option
 	command.Flags().BoolVar(&o.isCICD, "cicd", false, "Provide this flag if the target Git repository is a CI/CD configuration repository")

--- a/pkg/cmd/webhook/webhook_cmd.go
+++ b/pkg/cmd/webhook/webhook_cmd.go
@@ -45,7 +45,7 @@ func (o *options) setFlags(command *cobra.Command) {
 	command.Flags().StringVar(&o.pipelinesFolderPath, "pipelines-folder", ".", "Folder path to retrieve manifest, eg. /test where manifest exists at /test/pipelines.yaml")
 
 	// access-token option
-	command.Flags().StringVar(&o.accessToken, "access-token", "", "Access token to be used to create Git repository webhook (will update the token in the keyring if present)")
+	command.Flags().StringVar(&o.accessToken, "access-token", "", "Access token to be used to create Git repository webhook. Access token will be updated in the keyring")
 
 	// cicd option
 	command.Flags().BoolVar(&o.isCICD, "cicd", false, "Provide this flag if the target Git repository is a CI/CD configuration repository")

--- a/pkg/pipelines/accesstoken/accesstoken.go
+++ b/pkg/pipelines/accesstoken/accesstoken.go
@@ -1,6 +1,7 @@
 package accesstoken
 
 import (
+	"errors"
 	"fmt"
 	"net/url"
 	"os"
@@ -30,6 +31,25 @@ func GetAccessToken(gitRepoURL string) (string, error) {
 		}
 	}
 	return accessToken, nil
+}
+
+//CheckGitAccessToken sets the acceesstoken in the keyring if access-token is present, else it tries to retrieve it from the keyring/env-var
+func CheckGitAccessToken(accessToken, repoURL string) (string, error) {
+	if accessToken != "" {
+		err := SetSecret(repoURL, accessToken)
+		if err == nil {
+			return accessToken, nil
+		}
+		return "", err
+	}
+	secret, err := GetAccessToken(repoURL)
+	if err != nil {
+		return "", err
+	}
+	if secret == "" && err == nil {
+		return "", errors.New("unable to retrieve the access token from the keyring/env-var: kindly pass the --git-host-access-token")
+	}
+	return secret, nil
 }
 
 // HostFromURL extracts the hostname from the url passed

--- a/pkg/pipelines/accesstoken/accesstoken.go
+++ b/pkg/pipelines/accesstoken/accesstoken.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/redhat-developer/kam/pkg/cmd/ui"
 	"github.com/zalando/go-keyring"
 )
 
@@ -33,10 +34,14 @@ func GetAccessToken(gitRepoURL string) (string, error) {
 	return accessToken, nil
 }
 
-//CheckGitAccessToken sets the acceesstoken in the keyring if access-token is present, else it tries to retrieve it from the keyring/env-var
+//CheckGitAccessToken sets the access-token in the keyring if access-token is present, else it tries to retrieve it from the keyring/env-var
 func CheckGitAccessToken(accessToken, repoURL string) (string, error) {
 	if accessToken != "" {
-		err := SetSecret(repoURL, accessToken)
+		err := ui.ValidateAccessToken(accessToken, repoURL)
+		if err != nil {
+			return "", fmt.Errorf("Please enter a valid access token: %v", err)
+		}
+		err = SetSecret(repoURL, accessToken)
 		if err == nil {
 			return accessToken, nil
 		}

--- a/pkg/pipelines/accesstoken/accesstoken.go
+++ b/pkg/pipelines/accesstoken/accesstoken.go
@@ -1,0 +1,76 @@
+package accesstoken
+
+import (
+	"fmt"
+	"net/url"
+	"os"
+	"strings"
+
+	"github.com/zalando/go-keyring"
+)
+
+// KeyringServiceName refers to service name used to set the accesstoken in the keyring
+const KeyringServiceName = "kam"
+
+// GetAccessToken returns the token from either that is stored in the keyring or the environment variable in this order.
+func GetAccessToken(gitRepoURL string) (string, error) {
+	hostName, err := HostFromURL(gitRepoURL)
+	if err != nil {
+		return "", err
+	}
+	accessToken, err := keyring.Get(KeyringServiceName, hostName)
+	if err != nil && err != keyring.ErrNotFound {
+		return "", err
+	}
+	if err != nil && err == keyring.ErrNotFound {
+		envVarName := GetEnvVarName(hostName)
+		accessToken = os.Getenv(envVarName)
+		if accessToken == "" {
+			return "", nil
+		}
+	}
+	return accessToken, nil
+}
+
+// HostFromURL extracts the hostname from the url passed
+func HostFromURL(s string) (string, error) {
+	p, err := url.Parse(s)
+	if err != nil {
+		return "", err
+	}
+	return strings.ToLower(p.Host), nil
+}
+
+//SetSecret sets the secret in the keyring
+func SetSecret(repoURL, accessToken string) error {
+	hostName, err := HostFromURL(repoURL)
+	if err != nil {
+		return err
+	}
+	secret, err := getSecret(hostName)
+	if err != nil {
+		return err
+	}
+	if accessToken != secret {
+		err := keyring.Set(KeyringServiceName, hostName, accessToken)
+		if err != nil {
+			return fmt.Errorf("unable to set access token for repo %q using keyring: %w", repoURL, err)
+		}
+	}
+	return nil
+}
+
+//GetEnvVarName contains the logic for the naming convention of the environment variable that contains the accesstoken
+func GetEnvVarName(hostName string) string {
+	FmtHostName := strings.ReplaceAll(hostName, ".", "_")
+	envVarName := strings.ToUpper(FmtHostName) + "_TOKEN"
+	return envVarName
+}
+
+func getSecret(hostName string) (string, error) {
+	secret, err := keyring.Get(KeyringServiceName, hostName)
+	if err != nil && err != keyring.ErrNotFound {
+		return "", err
+	}
+	return secret, nil
+}

--- a/pkg/pipelines/accesstoken/accesstoken_test.go
+++ b/pkg/pipelines/accesstoken/accesstoken_test.go
@@ -1,0 +1,58 @@
+package accesstoken
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/zalando/go-keyring"
+)
+
+func TestGetAccessToken(t *testing.T) {
+	keyring.MockInit()
+	optionTests := []struct {
+		name             string
+		gitRepo          string
+		envVarPresent    bool
+		tokenRingPresent bool
+		hostName         string
+		expectedToken    string
+	}{
+		{"Github Token not present in keyring/env-var", "https://github.com/example/test.git", false, false, "github.com", ""},
+		{"Github Token present in env-var", "https://github.com/example/test.git", true, false, "github.com", "abc123"},
+		{"Github Token present in keyring", "https://github.com/example/test.git", false, true, "github.com", "xyz123"},
+		{"Github Token defaults to keyring although env-var present", "https://github.com/example/test.git", true, true, "github.com", "xyz123"},
+		{"Gitlab Token not present in keyring/env-var", "https://gitlab.com/example/test.git", false, false, "gitlab.com", ""},
+		{"Gitlab Token present in env-var", "https://gitlab.com/example/test.git", true, false, "gitlab.com", "abc123"},
+		{"Gitlab Token present in keyring", "https://gitlab.com/example/test.git", false, true, "gitlab.com", "xyz123"},
+		{"Gitlab Token defaults to keyring although env-var present", "https://gitlab.com/example/test.git", true, true, "gitlab.com", "xyz123"},
+	}
+
+	for i, tt := range optionTests {
+		t.Run(fmt.Sprintf("Test %d", i), func(t *testing.T) {
+			hostName, err := HostFromURL(tt.gitRepo)
+			if err != nil {
+				t.Error("Failed to get host name from access token")
+			}
+			envVar := GetEnvVarName(hostName)
+			defer os.Unsetenv(envVar)
+			if tt.envVarPresent {
+				err := os.Setenv(envVar, "abc123")
+				if err != nil {
+					t.Errorf("Error in setting the environment variable")
+				}
+			}
+			if tt.tokenRingPresent {
+				err := keyring.Set(KeyringServiceName, tt.hostName, "xyz123")
+				if err != nil {
+					t.Error(err)
+				}
+			}
+			token, _ := GetAccessToken(tt.gitRepo)
+
+			if token != tt.expectedToken {
+				t.Errorf("%v : GetAcessToken returned %v, expected %v", tt.name, token, tt.expectedToken)
+			}
+		})
+	}
+}

--- a/pkg/pipelines/accesstoken/accesstoken_test.go
+++ b/pkg/pipelines/accesstoken/accesstoken_test.go
@@ -74,7 +74,7 @@ func TestKeyRingFlagSet(t *testing.T) {
 	}
 
 	for _, tt := range optionTests {
-		_, err := CheckGitAccessToken(tt.gitToken, tt.gitRepo)
+		err := SetSecret(tt.gitRepo, tt.gitToken)
 		if err != nil {
 			t.Errorf("checkGitAccessToken() mode failed with error: %v", err)
 		}
@@ -127,6 +127,36 @@ func TestKeyRingFlagNotSet(t *testing.T) {
 			}
 			if tt.expectedToken != secret {
 				t.Fatalf("TestKeyRingFlagNotSet() Failed since expected token %v did not match %v", tt.expectedToken, secret)
+			}
+		})
+	}
+}
+
+func TestAccessToken(t *testing.T) {
+	keyring.MockInit()
+	cmdTests := []struct {
+		desc      string
+		testToken string
+		testURL   string
+		wantErr   string
+	}{
+		{"Access Token is incorrect",
+			"test123",
+			"https://github.com/user/repo.git",
+			"Please enter a valid access token: The token passed is incorrect for repository user/repo",
+		},
+		{"Unable to retrieve token from keyring/env-var",
+			"",
+			"https://github.com/user/repo.git",
+			"unable to retrieve the access token from the keyring/env-var: kindly pass the --git-host-access-token",
+		},
+	}
+
+	for _, tt := range cmdTests {
+		t.Run(tt.desc, func(t *testing.T) {
+			_, err := CheckGitAccessToken(tt.testToken, tt.testURL)
+			if err.Error() != tt.wantErr {
+				t.Errorf("got %s, want %s", err, tt.wantErr)
 			}
 		})
 	}

--- a/pkg/pipelines/accesstoken/accesstoken_test.go
+++ b/pkg/pipelines/accesstoken/accesstoken_test.go
@@ -18,7 +18,7 @@ func TestGetAccessToken(t *testing.T) {
 		hostName         string
 		expectedToken    string
 	}{
-		{"Github Token not present in keyring/env-var", "https://github.com/example/test.git", false, false, "github.com", ""},
+		{"Github Token not present in keyring/env-var", "https://githubtest.com/example/test.git", false, false, "github.com", ""},
 		{"Github Token present in env-var", "https://github.com/example/test.git", true, false, "github.com", "abc123"},
 		{"Github Token present in keyring", "https://github.com/example/test.git", false, true, "github.com", "xyz123"},
 		{"Github Token defaults to keyring although env-var present", "https://github.com/example/test.git", true, true, "github.com", "xyz123"},
@@ -52,6 +52,81 @@ func TestGetAccessToken(t *testing.T) {
 
 			if token != tt.expectedToken {
 				t.Errorf("%v : GetAcessToken returned %v, expected %v", tt.name, token, tt.expectedToken)
+			}
+		})
+	}
+}
+
+func TestKeyRingFlagSet(t *testing.T) {
+	keyring.MockInit()
+	optionTests := []struct {
+		name          string
+		gitRepo       string
+		imagerepo     string
+		gitToken      string
+		expectedKey   string
+		expectedToken string
+	}{
+		{"set the github access token in keyring", "https://github.com/example/service.git", "registry/username/repo", "abc123", "github.com", "abc123"},
+		{"overwrite github access token in keyring", "https://github.com/example/service.git", "registry/username/repo", "xyz123", "github.com", "xyz123"},
+		{"set the gitlab access Token in keyring", "https://gitlab.com/example/service.git", "registry/username/repo", "test123", "gitlab.com", "test123"},
+		{"overwrite gitlab access token in keyring", "https://gitlab.com/example/service.git", "registry/username/repo", "test345", "gitlab.com", "test345"},
+	}
+
+	for _, tt := range optionTests {
+		_, err := CheckGitAccessToken(tt.gitToken, tt.gitRepo)
+		if err != nil {
+			t.Errorf("checkGitAccessToken() mode failed with error: %v", err)
+		}
+		gitopsToken, _ := keyring.Get(KeyringServiceName, tt.expectedKey)
+		if tt.expectedToken != gitopsToken {
+			t.Errorf("TestKeyRingFlagSet() Failed since expected token %v did not match %v", tt.expectedToken, gitopsToken)
+		}
+	}
+}
+
+func TestKeyRingFlagNotSet(t *testing.T) {
+	keyring.MockInit()
+	optionTests := []struct {
+		name          string
+		serviceRepo   string
+		gitToken      string
+		envVarPresent bool
+		keyRing       bool
+		expectedToken string
+	}{
+		{"with token in keyring present(github)", "https://github.com/example/service.git", "abc123", true, false, "abc123"},
+		{"with token in environment variable(github)", "https://github.com/example/service.git", "xyz123", false, true, "xyz123"},
+		{"with token in keyring present(gitlab)", "https://gitlab.com/example/service.git", "xyz123", true, false, "xyz123"},
+		{"with token in environment variable(github)", "https://gitlab.com/example/service.git", "xyz123", false, true, "xyz123"},
+	}
+
+	for i, tt := range optionTests {
+		t.Run(fmt.Sprintf("Test %d", i), func(t *testing.T) {
+			hostName, err := HostFromURL(tt.serviceRepo)
+			if err != nil {
+				t.Error("Failed to get host name from access token")
+			}
+			envVar := GetEnvVarName(hostName)
+			defer os.Unsetenv(envVar)
+			if tt.envVarPresent {
+				err := os.Setenv(envVar, tt.expectedToken)
+				if err != nil {
+					t.Errorf("Error in setting the environment variable")
+				}
+			}
+			if tt.keyRing {
+				err := keyring.Set("kam", hostName, tt.expectedToken)
+				if err != nil {
+					t.Error(err)
+				}
+			}
+			secret, err := CheckGitAccessToken("", tt.serviceRepo)
+			if err != nil {
+				t.Errorf("checkGitAccessToken() mode failed with error: %v", err)
+			}
+			if tt.expectedToken != secret {
+				t.Fatalf("TestKeyRingFlagNotSet() Failed since expected token %v did not match %v", tt.expectedToken, secret)
 			}
 		})
 	}

--- a/pkg/pipelines/bootstrap.go
+++ b/pkg/pipelines/bootstrap.go
@@ -82,6 +82,7 @@ type BootstrapOptions struct {
 	GitHostAccessToken       string               // The auth token to use to send commit-status notifications, and access private repositories.
 	Overwrite                bool                 // This allows to overwrite if there is an existing gitops repository
 	ServiceRepoURL           string               // This is the full URL to your GitHub repository for your app source.
+	SaveTokenKeyRing         string               // This is the access-token to be updated in the keyring of local-file-system.
 	ServiceWebhookSecret     string               // This is the secret for authenticating hooks from your app source.
 	PrivateRepoDriver        string               // Records the type of the GitOpsRepoURL driver if not a well-known host.
 	CommitStatusTracker      bool                 // If true, this is a "private repository", i.e. requires authentication to clone the repository.

--- a/pkg/pipelines/bootstrap.go
+++ b/pkg/pipelines/bootstrap.go
@@ -82,7 +82,7 @@ type BootstrapOptions struct {
 	GitHostAccessToken       string               // The auth token to use to send commit-status notifications, and access private repositories.
 	Overwrite                bool                 // This allows to overwrite if there is an existing gitops repository
 	ServiceRepoURL           string               // This is the full URL to your GitHub repository for your app source.
-	SaveTokenKeyRing         string               // This is the access-token to be updated in the keyring of local-file-system.
+	SaveTokenKeyRing         bool                 // If true, the access-token will be saved in the keyring
 	ServiceWebhookSecret     string               // This is the secret for authenticating hooks from your app source.
 	PrivateRepoDriver        string               // Records the type of the GitOpsRepoURL driver if not a well-known host.
 	CommitStatusTracker      bool                 // If true, this is a "private repository", i.e. requires authentication to clone the repository.

--- a/pkg/pipelines/webhook/webhook.go
+++ b/pkg/pipelines/webhook/webhook.go
@@ -102,9 +102,11 @@ func newWebhookInfo(accessToken, pipelinesFile string, serviceName *QualifiedSer
 	if err != nil {
 		return nil, fmt.Errorf("failed to get event listener URL: %v", err)
 	}
-	accessToken, err = accesstoken.CheckGitAccessToken(accessToken, gitRepoURL)
-	if err != nil {
-		return nil, err
+	if accessToken == "" {
+		accessToken, err = accesstoken.GetAccessToken(gitRepoURL)
+		if err != nil {
+			return nil, fmt.Errorf("unable to use access-token from keyring/env-var: %v, please pass a valid token to --save-token-keyring", err)
+		}
 	}
 	repository, err := git.NewRepository(gitRepoURL, accessToken)
 	if err != nil {

--- a/pkg/pipelines/webhook/webhook.go
+++ b/pkg/pipelines/webhook/webhook.go
@@ -102,7 +102,7 @@ func newWebhookInfo(accessToken, pipelinesFile string, serviceName *QualifiedSer
 	if err != nil {
 		return nil, fmt.Errorf("failed to get event listener URL: %v", err)
 	}
-	accessToken, err = accesstoken.CheckGitAccessToken(gitRepoURL, accessToken)
+	accessToken, err = accesstoken.CheckGitAccessToken(accessToken, gitRepoURL)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/pipelines/webhook/webhook.go
+++ b/pkg/pipelines/webhook/webhook.go
@@ -102,20 +102,9 @@ func newWebhookInfo(accessToken, pipelinesFile string, serviceName *QualifiedSer
 	if err != nil {
 		return nil, fmt.Errorf("failed to get event listener URL: %v", err)
 	}
-	if accessToken == "" {
-		accessToken, err = accesstoken.GetAccessToken(gitRepoURL)
-		if err != nil {
-			return nil, err
-		}
-		if accessToken == "" && err == nil {
-			return nil, errors.New("unable to retrieve access-token from keyring/environment variables")
-		}
-	} else {
-		err := accesstoken.SetSecret(gitRepoURL, accessToken)
-		if err != nil {
-			return nil, err
-		}
-
+	accessToken, err = accesstoken.CheckGitAccessToken(gitRepoURL, accessToken)
+	if err != nil {
+		return nil, err
 	}
 	repository, err := git.NewRepository(gitRepoURL, accessToken)
 	if err != nil {

--- a/pkg/pipelines/webhook/webhook.go
+++ b/pkg/pipelines/webhook/webhook.go
@@ -141,8 +141,8 @@ func GetAccessToken(gitRepoURL string) (string, error) {
 		return "", err
 	}
 	if err != nil && err == keyring.ErrNotFound {
-		hN := strings.ReplaceAll(hostName, ".", "_")
-		envVar := strings.ToUpper(hN) + "_TOKEN"
+		FmtHostName := strings.ReplaceAll(hostName, ".", "_")
+		envVar := strings.ToUpper(FmtHostName) + "_TOKEN"
 		accessToken = os.Getenv(envVar)
 		if accessToken == "" {
 			return "", nil

--- a/pkg/pipelines/webhook/webhook_test.go
+++ b/pkg/pipelines/webhook/webhook_test.go
@@ -137,20 +137,25 @@ func TestGetAccessToken(t *testing.T) {
 		gitRepo          string
 		envVarPresent    bool
 		tokenRingPresent bool
+		hostName         string
 		expectedToken    string
 	}{
-		{"GitToken not present in keyring/env-var", "https://github.com/example/test.git", false, false, ""},
-		{"GitToken present in env-var", "https://github.com/example/test.git", true, false, "abc123"},
-		{"GitToken present in keyring", "https://github.com/example/test.git", false, true, "xyz123"},
-		{"GitToken defaults to keyring although env-var present", "https://github.com/example/test.git", true, true, "xyz123"},
+		{"Github Token not present in keyring/env-var", "https://github.com/example/test.git", false, false, "github.com", ""},
+		{"Github Token present in env-var", "https://github.com/example/test.git", true, false, "github.com", "abc123"},
+		{"Github Token present in keyring", "https://github.com/example/test.git", false, true, "github.com", "xyz123"},
+		{"Github Token defaults to keyring although env-var present", "https://github.com/example/test.git", true, true, "github.com", "xyz123"},
+		{"Gitlab Token not present in keyring/env-var", "https://gitlab.com/example/test.git", false, false, "gitlab.com", ""},
+		{"Gitlab Token present in env-var", "https://gitlab.com/example/test.git", true, false, "gitlab.com", "abc123"},
+		{"Gitlab Token present in keyring", "https://gitlab.com/example/test.git", false, true, "gitlab.com", "xyz123"},
+		{"Gitlab Token defaults to keyring although env-var present", "https://gitlab.com/example/test.git", true, true, "gitlab.com", "xyz123"},
 	}
 
 	for _, tt := range optionTests {
 		if tt.envVarPresent {
-			os.Setenv("testGitToken", "abc123")
+			os.Setenv("TESTGITTOKEN", "abc123")
 		}
 		if tt.tokenRingPresent {
-			err := keyring.Set("kam", tt.gitRepo, "xyz123")
+			err := keyring.Set("kam", tt.hostName, "xyz123")
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -160,6 +165,6 @@ func TestGetAccessToken(t *testing.T) {
 		if token != tt.expectedToken {
 			t.Fatalf("getAcessToken returned %v, expected %v", token, tt.expectedToken)
 		}
-		os.Unsetenv("testGitToken")
+		os.Unsetenv("TESTGITTOKEN")
 	}
 }

--- a/pkg/pipelines/webhook/webhook_test.go
+++ b/pkg/pipelines/webhook/webhook_test.go
@@ -160,7 +160,7 @@ func TestGetAccessToken(t *testing.T) {
 				}
 			}
 			if tt.tokenRingPresent {
-				err := keyring.Set("kam", tt.hostName, "xyz123")
+				err := keyring.Set(KeyringServiceName, tt.hostName, "xyz123")
 				if err != nil {
 					t.Error(err)
 				}

--- a/pkg/pipelines/webhook/webhook_test.go
+++ b/pkg/pipelines/webhook/webhook_test.go
@@ -150,25 +150,26 @@ func TestGetAccessToken(t *testing.T) {
 		{"Gitlab Token defaults to keyring although env-var present", "https://gitlab.com/example/test.git", true, true, "gitlab.com", "xyz123"},
 	}
 
-	for _, tt := range optionTests {
-		if tt.envVarPresent {
-			err := os.Setenv("TESTGITTOKEN", "abc123")
-			if err != nil {
-				t.Errorf("Error in setting the environment variable")
-			}
+	for i, tt := range optionTests {
+		t.Run(fmt.Sprintf("Test %d", i), func(t *testing.T) {
 			defer os.Unsetenv("TESTGITTOKEN")
-		}
-		if tt.tokenRingPresent {
-			err := keyring.Set("kam", tt.hostName, "xyz123")
-			if err != nil {
-				t.Error(err)
+			if tt.envVarPresent {
+				err := os.Setenv("TESTGITTOKEN", "abc123")
+				if err != nil {
+					t.Errorf("Error in setting the environment variable")
+				}
 			}
-		}
-		token, _ := getAccessToken(tt.gitRepo)
+			if tt.tokenRingPresent {
+				err := keyring.Set("kam", tt.hostName, "xyz123")
+				if err != nil {
+					t.Error(err)
+				}
+			}
+			token, _ := getAccessToken(tt.gitRepo)
 
-		if token != tt.expectedToken {
-			t.Errorf("%v : getAcessToken returned %v, expected %v", tt.name, token, tt.expectedToken)
-		}
-		os.Unsetenv("TESTGITTOKEN")
+			if token != tt.expectedToken {
+				t.Errorf("%v : getAcessToken returned %v, expected %v", tt.name, token, tt.expectedToken)
+			}
+		})
 	}
 }

--- a/pkg/pipelines/webhook/webhook_test.go
+++ b/pkg/pipelines/webhook/webhook_test.go
@@ -2,14 +2,10 @@ package webhook
 
 import (
 	"fmt"
-	"os"
 	"testing"
-
-	"strings"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/redhat-developer/kam/pkg/pipelines/config"
-	"github.com/zalando/go-keyring"
 )
 
 func TestBuildURL(t *testing.T) {
@@ -127,56 +123,6 @@ func TestGetGitRepoURL(t *testing.T) {
 			got := getRepoURL(tt.manifest, tt.isCICD, tt.serviceName)
 			if diff := cmp.Diff(got, tt.want); diff != "" {
 				t.Errorf("result mismatch got\n%s", diff)
-			}
-		})
-	}
-}
-
-func TestGetAccessToken(t *testing.T) {
-	keyring.MockInit()
-	optionTests := []struct {
-		name             string
-		gitRepo          string
-		envVarPresent    bool
-		tokenRingPresent bool
-		hostName         string
-		expectedToken    string
-	}{
-		{"Github Token not present in keyring/env-var", "https://github.com/example/test.git", false, false, "github.com", ""},
-		{"Github Token present in env-var", "https://github.com/example/test.git", true, false, "github.com", "abc123"},
-		{"Github Token present in keyring", "https://github.com/example/test.git", false, true, "github.com", "xyz123"},
-		{"Github Token defaults to keyring although env-var present", "https://github.com/example/test.git", true, true, "github.com", "xyz123"},
-		{"Gitlab Token not present in keyring/env-var", "https://gitlab.com/example/test.git", false, false, "gitlab.com", ""},
-		{"Gitlab Token present in env-var", "https://gitlab.com/example/test.git", true, false, "gitlab.com", "abc123"},
-		{"Gitlab Token present in keyring", "https://gitlab.com/example/test.git", false, true, "gitlab.com", "xyz123"},
-		{"Gitlab Token defaults to keyring although env-var present", "https://gitlab.com/example/test.git", true, true, "gitlab.com", "xyz123"},
-	}
-
-	for i, tt := range optionTests {
-		t.Run(fmt.Sprintf("Test %d", i), func(t *testing.T) {
-			hostName, err := HostFromURL(tt.gitRepo)
-			if err != nil {
-				t.Error("Failed to get host name from access token")
-			}
-			h := strings.ReplaceAll(hostName, ".", "_")
-			envVar := strings.ToUpper(h) + "_TOKEN"
-			defer os.Unsetenv(envVar)
-			if tt.envVarPresent {
-				err := os.Setenv(envVar, "abc123")
-				if err != nil {
-					t.Errorf("Error in setting the environment variable")
-				}
-			}
-			if tt.tokenRingPresent {
-				err := keyring.Set(KeyringServiceName, tt.hostName, "xyz123")
-				if err != nil {
-					t.Error(err)
-				}
-			}
-			token, _ := GetAccessToken(tt.gitRepo)
-
-			if token != tt.expectedToken {
-				t.Errorf("%v : GetAcessToken returned %v, expected %v", tt.name, token, tt.expectedToken)
 			}
 		})
 	}

--- a/pkg/pipelines/webhook/webhook_test.go
+++ b/pkg/pipelines/webhook/webhook_test.go
@@ -5,6 +5,8 @@ import (
 	"os"
 	"testing"
 
+	"strings"
+
 	"github.com/google/go-cmp/cmp"
 	"github.com/redhat-developer/kam/pkg/pipelines/config"
 	"github.com/zalando/go-keyring"
@@ -152,9 +154,15 @@ func TestGetAccessToken(t *testing.T) {
 
 	for i, tt := range optionTests {
 		t.Run(fmt.Sprintf("Test %d", i), func(t *testing.T) {
-			defer os.Unsetenv("TESTGITTOKEN")
+			hostName, err := HostFromURL(tt.gitRepo)
+			if err != nil {
+				t.Error("Failed to get host name from access token")
+			}
+			h := strings.ReplaceAll(hostName, ".", "_")
+			envVar := strings.ToUpper(h) + "_TOKEN"
+			defer os.Unsetenv(envVar)
 			if tt.envVarPresent {
-				err := os.Setenv("TESTGITTOKEN", "abc123")
+				err := os.Setenv(envVar, "abc123")
 				if err != nil {
 					t.Errorf("Error in setting the environment variable")
 				}
@@ -165,10 +173,10 @@ func TestGetAccessToken(t *testing.T) {
 					t.Error(err)
 				}
 			}
-			token, _ := getAccessToken(tt.gitRepo)
+			token, _ := GetAccessToken(tt.gitRepo)
 
 			if token != tt.expectedToken {
-				t.Errorf("%v : getAcessToken returned %v, expected %v", tt.name, token, tt.expectedToken)
+				t.Errorf("%v : GetAcessToken returned %v, expected %v", tt.name, token, tt.expectedToken)
 			}
 		})
 	}

--- a/pkg/pipelines/webhook/webhook_test.go
+++ b/pkg/pipelines/webhook/webhook_test.go
@@ -152,18 +152,22 @@ func TestGetAccessToken(t *testing.T) {
 
 	for _, tt := range optionTests {
 		if tt.envVarPresent {
-			os.Setenv("TESTGITTOKEN", "abc123")
+			err := os.Setenv("TESTGITTOKEN", "abc123")
+			if err != nil {
+				t.Errorf("Error in setting the environment variable")
+			}
+			defer os.Unsetenv("TESTGITTOKEN")
 		}
 		if tt.tokenRingPresent {
 			err := keyring.Set("kam", tt.hostName, "xyz123")
 			if err != nil {
-				t.Fatal(err)
+				t.Error(err)
 			}
 		}
 		token, _ := getAccessToken(tt.gitRepo)
 
 		if token != tt.expectedToken {
-			t.Fatalf("getAcessToken returned %v, expected %v", token, tt.expectedToken)
+			t.Errorf("%v : getAcessToken returned %v, expected %v", tt.name, token, tt.expectedToken)
 		}
 		os.Unsetenv("TESTGITTOKEN")
 	}


### PR DESCRIPTION
**What type of PR is this?**
> /kind enhancement

**What does this PR do / why we need it**:
This feature allows you to set the token at the time of bootstrap and can be reused at the time of the webhook create.

**Have you updated the necessary documentation?**
* [x] Documentation update is required by this PR.
* [ ] Documentation has been updated.

Will be addressed after Pr is approved.

**Which issue(s) this PR fixes**:
https://issues.redhat.com/browse/GITOPS-349

