### PR TITLE
Break link app env

### DIFF
--- a/pkg/pipelines/environments/environments.go
+++ b/pkg/pipelines/environments/environments.go
@@ -55,7 +55,7 @@ func Build(fs afero.Fs, m *config.Manifest, saName string, o AppLinks) (res.Reso
 
 func (b *envBuilder) Application(env *config.Environment, app *config.Application) error {
 	appPath := filepath.Join(config.PathForApplication(env, app))
-	appFiles, err := filesForApplication(env, appPath, app, b.appLinks)
+	appFiles, err := filesForApplication(env, appPath, app)
 	if err != nil {
 		return err
 	}
@@ -125,9 +125,7 @@ func filesForEnvironment(basePath string, env *config.Environment, gitOpsRepoURL
 	return envFiles
 }
 
-func filesForApplication(env *config.Environment, appPath string, app *config.Application, o AppLinks) (res.Resources, error) {
-	envPath := filepath.Join(config.PathForEnvironment(env), "env")
-	envBasePath := filepath.Join(envPath, "base")
+func filesForApplication(env *config.Environment, appPath string, app *config.Application) (res.Resources, error) {
 	envFiles := res.Resources{}
 	basePath := filepath.Join(appPath, "base")
 	overlaysPath := filepath.Join(appPath, "overlays")
@@ -145,14 +143,6 @@ func filesForApplication(env *config.Environment, appPath string, app *config.Ap
 			return nil, err
 		}
 		relServices = append(relServices, relService)
-	}
-
-	if o == AppsToEnvironments {
-		relEnv, err := filepath.Rel(filepath.Dir(baseKustomization), envBasePath)
-		if err != nil {
-			return nil, err
-		}
-		relServices = append(relServices, relEnv)
 	}
 
 	envFiles[filepath.Join(appPath, kustomization)] = &res.Kustomization{Bases: []string{"overlays"}}

--- a/pkg/pipelines/environments/environments_test.go
+++ b/pkg/pipelines/environments/environments_test.go
@@ -24,10 +24,11 @@ func TestBuildEnvironmentFilesWithAppsToEnvironment(t *testing.T) {
 		t.Fatal(err)
 	}
 	want := res.Resources{
-		"environments/test-dev/apps/my-app-1/base/kustomization.yaml": &res.Kustomization{Bases: []string{
-			"../services/service-http",
-			"../services/service-metrics",
-			"../../../env/base"},
+		"environments/test-dev/apps/my-app-1/base/kustomization.yaml": &res.Kustomization{
+			Bases: []string{
+				"../services/service-http",
+				"../services/service-metrics",
+			},
 		},
 		"environments/test-dev/apps/my-app-1/kustomization.yaml":                                   &res.Kustomization{Bases: []string{"overlays"}},
 		"environments/test-dev/apps/my-app-1/overlays/kustomization.yaml":                          &res.Kustomization{Bases: []string{"../base"}},
@@ -169,7 +170,7 @@ func TestBuildEnvironmentFilesWithNoCICDEnv(t *testing.T) {
 			Bases: []string{
 				"../services/service-http",
 				"../services/service-metrics",
-				"../../../env/base"},
+			},
 		},
 		"environments/test-dev/apps/my-app-1/kustomization.yaml":                                   &res.Kustomization{Bases: []string{"overlays"}},
 		"environments/test-dev/apps/my-app-1/overlays/kustomization.yaml":                          &res.Kustomization{Bases: []string{"../base"}},

--- a/pkg/pipelines/service_test.go
+++ b/pkg/pipelines/service_test.go
@@ -105,7 +105,12 @@ func TestServiceResourcesWithArgoCD(t *testing.T) {
 	m := buildManifest(false, true)
 
 	want := res.Resources{
-		"environments/test-dev/apps/test-app/base/kustomization.yaml":     &res.Kustomization{Bases: []string{"../services/test-svc", "../services/test", "../../../env/base"}},
+		"environments/test-dev/apps/test-app/base/kustomization.yaml": &res.Kustomization{
+			Bases: []string{
+				"../services/test-svc",
+				"../services/test",
+			},
+		},
 		"environments/test-dev/apps/test-app/kustomization.yaml":          &res.Kustomization{Bases: []string{"overlays"}},
 		"environments/test-dev/apps/test-app/overlays/kustomization.yaml": &res.Kustomization{Bases: []string{"../base"}},
 		"pipelines.yaml": &config.Manifest{


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What does this PR do / why we need it**:

This breaks the link between apps and environments.

Previously, an app depended on its services, _and_ on its environment, this meant that you could bring up an app, and have it bring up the environment-defined resources.

This lead to issues, because an environment with multiple apps triggered a warning about multiple applications managing the same resource.

This change breaks this link, and introduces a per-env app, which is the recommended method for argo-cd.

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:

By default, this results in application being created by the argocd resource builder for each environment defined in the pipelines.yaml file.

![image](https://user-images.githubusercontent.com/867746/99947560-13667180-2d70-11eb-9a6e-9265d72680f8.png)

