### PR TITLE
Generated argocd application to use overlays folder instead of base

### DIFF
--- a/pkg/pipelines/argocd/argocd.go
+++ b/pkg/pipelines/argocd/argocd.go
@@ -162,7 +162,7 @@ func makeAppSource(env *config.Environment, app *config.Application, repoURL str
 	if app.ConfigRepo == nil {
 		return &argoappv1.ApplicationSource{
 			RepoURL: repoURL,
-			Path:    filepath.Join(config.PathForApplication(env, app), "base"),
+			Path:    filepath.Join(config.PathForApplication(env, app), "overlays"),
 		}
 	}
 	return &argoappv1.ApplicationSource{
@@ -174,7 +174,7 @@ func makeAppSource(env *config.Environment, app *config.Application, repoURL str
 
 func makeEnvSource(env *config.Environment, repoURL string) *argoappv1.ApplicationSource {
 	envPath := filepath.Join(config.PathForEnvironment(env), "env")
-	envBasePath := filepath.Join(envPath, "base")
+	envBasePath := filepath.Join(envPath, "overlays")
 	return &argoappv1.ApplicationSource{
 		RepoURL: repoURL,
 		Path:    envBasePath,

--- a/pkg/pipelines/argocd/argocd_test.go
+++ b/pkg/pipelines/argocd/argocd_test.go
@@ -1,6 +1,7 @@
 package argocd
 
 import (
+	"path/filepath"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -35,6 +36,9 @@ var (
 			testApp,
 		},
 	}
+
+	testEnvPath     = filepath.Join(config.PathForEnvironment(testEnv), "env")
+	testEnvBasePath = filepath.Join(testEnvPath, "overlays")
 )
 
 func TestBuildCreatesArgoCD(t *testing.T) {
@@ -57,7 +61,10 @@ func TestBuildCreatesArgoCD(t *testing.T) {
 			TypeMeta:   applicationTypeMeta,
 			ObjectMeta: meta.ObjectMeta(meta.NamespacedName(ArgoCDNamespace, "test-dev-env")),
 			Spec: argoappv1.ApplicationSpec{
-				Source: *makeEnvSource(testEnv, testRepoURL),
+				Source: argoappv1.ApplicationSource{
+					RepoURL: testRepoURL,
+					Path:    testEnvBasePath,
+				},
 				Destination: argoappv1.ApplicationDestination{
 					Server:    defaultServer,
 					Namespace: "test-dev",
@@ -70,7 +77,10 @@ func TestBuildCreatesArgoCD(t *testing.T) {
 			TypeMeta:   applicationTypeMeta,
 			ObjectMeta: meta.ObjectMeta(meta.NamespacedName(ArgoCDNamespace, "test-dev-http-api")),
 			Spec: argoappv1.ApplicationSpec{
-				Source: *makeAppSource(testEnv, testEnv.Apps[0], testRepoURL),
+				Source: argoappv1.ApplicationSource{
+					RepoURL: testRepoURL,
+					Path:    filepath.Join(config.PathForApplication(testEnv, testApp), "overlays"),
+				},
 				Destination: argoappv1.ApplicationDestination{
 					Server:    defaultServer,
 					Namespace: "test-dev",


### PR DESCRIPTION
**What type of PR is this?**
> /kind bug

**What does this PR do / why we need it**:
Generated argocd application to use overlays folder instead of base. Given that we have an overlays directory, which is for users to override the base, we should be using the overlays directory, otherwise nothing that is put into the overlays will be picked up.

**Have you updated the necessary documentation?**
NA 

**Which issue(s) this PR fixes**:
NA

**How to test changes / Special notes to the reviewer**:
Run `kam bootstrap` and see if the generated argocd application (/config/argcod/<env>-<app>-app,xml) spec/source/path uses "overlays" folder instead of "base".
