### PR TITLE
Adding dbus-launch in test container PATH

### DIFF
--- a/openshift-ci/build-root/Dockerfile
+++ b/openshift-ci/build-root/Dockerfile
@@ -2,7 +2,7 @@
 
 FROM registry.svc.ci.openshift.org/openshift/release:golang-1.14
 
-RUN yum -y install dnf httpd-tools sudo
+RUN yum -y install dnf httpd-tools sudo dbus-x11
 
 RUN dnf -y install 'dnf-command(config-manager)'
 

--- a/scripts/openshiftci-presubmit-all-tests.sh
+++ b/scripts/openshiftci-presubmit-all-tests.sh
@@ -44,6 +44,8 @@ else
     exit 1
 fi
 
+git log -n 3
+
 # assert that kam is on the path
 kam version
 

--- a/scripts/openshiftci-presubmit-all-tests.sh
+++ b/scripts/openshiftci-presubmit-all-tests.sh
@@ -44,7 +44,7 @@ else
     exit 1
 fi
 
-git log -n 3
+git log -n 5
 
 # assert that kam is on the path
 kam version

--- a/scripts/openshiftci-presubmit-all-tests.sh
+++ b/scripts/openshiftci-presubmit-all-tests.sh
@@ -44,8 +44,6 @@ else
     exit 1
 fi
 
-git log -n 5
-
 # assert that kam is on the path
 kam version
 

--- a/scripts/openshiftci-presubmit-unittests.sh
+++ b/scripts/openshiftci-presubmit-unittests.sh
@@ -36,7 +36,6 @@ else
     echo "command-documentation is up-to-date."
 fi
 
-git log -n 5
 make bin
 kam version
 # crosscompile and publish artifacts

--- a/scripts/openshiftci-presubmit-unittests.sh
+++ b/scripts/openshiftci-presubmit-unittests.sh
@@ -7,7 +7,7 @@ set -x
 
 export ARTIFACTS_DIR="/tmp/artifacts"
 export CUSTOM_HOMEDIR=$ARTIFACTS_DIR
-export PATH=$PATH:$GOPATH/bin
+export PATH=$PATH:$GOPATH/bin:$(pwd)/bin
 # set location for golangci-lint cache
 # otherwise /.cache is used, and it fails on permission denied
 export GOLANGCI_LINT_CACHE="/tmp/.cache"
@@ -36,6 +36,9 @@ else
     echo "command-documentation is up-to-date."
 fi
 
+git log -n 5
+make bin
+kam version
 # crosscompile and publish artifacts
 make all_platforms
 


### PR DESCRIPTION
**What type of PR is this?**
/kind failing-test
/kind enhancement

**What does this PR do / why we need it**:
This fix will issue coming from another pr - https://github.com/redhat-developer/kam/pull/87

Issue log - https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/redhat-developer_kam/87/pull-ci-redhat-developer-kam-master-v4.5-integration-e2e/1333827600312700928#1:build-log.txt%3A943

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes ```Command stderr:  ✗  unable to use access-token from keyring/env-var: exec: "dbus-launch": executable file not found in $PATH, please pass a valid token to --git-host-access-token```

**How to test changes / Special notes to the reviewer**:
Pr https://github.com/redhat-developer/kam/pull/87 should not throw ```dbus-launch``` error