### PR TITLE
Don't fail when adding a service to an environment with no pipelines.

### DIFF
--- a/pkg/pipelines/service.go
+++ b/pkg/pipelines/service.go
@@ -99,7 +99,7 @@ func serviceResources(m *config.Manifest, appFs afero.Fs, o *AddServiceOptions) 
 		secretsPath := filepath.Join(config.PathForPipelines(cfg), "base", secretFilename)
 		files[secretsPath] = hookSecret
 
-		if o.ImageRepo != "" {
+		if o.ImageRepo != "" && env.Pipelines != nil {
 			_, resources, bindingName, err := createImageRepoResources(m, cfg, env, o)
 			if err != nil {
 				return nil, err


### PR DESCRIPTION
**What type of PR is this?**

> /kind bug

**What does this PR do / why we need it**:

Don't fail when you provide a service with an image to an environment with no pipelines

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #?

#102 

**How to test changes / Special notes to the reviewer**:
