### PR TITLE
Add default ref to namespaces.

### DIFF
--- a/pkg/pipelines/namespaces/namespaces.go
+++ b/pkg/pipelines/namespaces/namespaces.go
@@ -50,7 +50,7 @@ func Create(name, gitOpsRepoURL string) *corev1.Namespace {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
 			Annotations: map[string]string{
-				vcsURIAnnotation: gitOpsRepoURL,
+				vcsURIAnnotation: gitOpsRepoURL + "?ref=main",
 			},
 		},
 	}

--- a/pkg/pipelines/namespaces/namespaces_test.go
+++ b/pkg/pipelines/namespaces/namespaces_test.go
@@ -16,8 +16,10 @@ func TestCreate(t *testing.T) {
 	want := &corev1.Namespace{
 		TypeMeta: namespaceTypeMeta,
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        "test-environment",
-			Annotations: map[string]string{vcsURIAnnotation: testGitOpsRepoURL},
+			Name: "test-environment",
+			Annotations: map[string]string{
+				vcsURIAnnotation: testGitOpsRepoURL + "?ref=main",
+			},
 		},
 	}
 


### PR DESCRIPTION
We push the git repo to a "main" branch when it's being automatically created.

This generates the namespace with this default.

**What type of PR is this?**
> Uncomment only one ` /kind` line, and delete the rest.
> For example, `> /kind bug` would simply become: `/kind bug`


> /kind enhancement

**What does this PR do / why we need it**:

The vcs ref url is used by the Gitops backend to fetch the correct repo.

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:
