### PR TITLE
Interactive command validation/ clean up

### DIFF
--- a/pkg/cmd/bootstrap.go
+++ b/pkg/cmd/bootstrap.go
@@ -172,7 +172,6 @@ func initiateInteractiveMode(io *BootstrapParameters, client *utility.Client) er
 	if err != nil {
 		return err
 	}
-	serviceRepoParams.TokenAuthenticated = true
 	io.GitHostAccessToken = gitRepoParams.GitHostAccessToken
 	io.GitOpsRepoURL = gitRepoParams.RepoInfo.RepoURL
 	if !isKnownDriver(io.GitOpsRepoURL) {
@@ -192,14 +191,14 @@ func initiateInteractiveMode(io *BootstrapParameters, client *utility.Client) er
 		io.DockerConfigJSONFilename = ui.EnterDockercfg()
 	}
 	io.GitOpsWebhookSecret = ui.EnterGitWebhookSecret(io.GitOpsRepoURL)
-	err = ui.CheckRepoAccessTokenValidity(serviceRepoParams, ui.ServiceRepoType)
+	serviceRepoParams.RepoInfo.RepoURL = utility.AddGitSuffixIfNecessary(ui.EnterGitRepo(ui.ServiceRepoType))
+	err = ui.ValidateAccessToken(serviceRepoParams)
 	if err != nil {
 		return err
 	}
 	io.ServiceRepoURL = serviceRepoParams.RepoInfo.RepoURL
 	io.ServiceWebhookSecret = ui.EnterGitWebhookSecret(io.ServiceRepoURL)
 	io.CommitStatusTracker = ui.SetupCommitStatusTracker()
-	fmt.Println("This is the value of repovalid", gitRepoParams.RepoInfo.GitRepoValid)
 	if !gitRepoParams.RepoInfo.GitRepoValid {
 		io.PushToGit = ui.SelectOptionPushToGit()
 	}

--- a/pkg/cmd/bootstrap_test.go
+++ b/pkg/cmd/bootstrap_test.go
@@ -167,6 +167,35 @@ func TestValidateBootstrapParameter(t *testing.T) {
 	}
 }
 
+func TestValidateURLCorrection(t *testing.T) {
+	optionTests := []struct {
+		name           string
+		gitRepo        string
+		serviceRepo    string
+		wantGitopsURL  string
+		wantServiceURL string
+	}{
+		{"gitops-repo/service repo unchanged", "https://github.com/username/repo.git", "https://github.com/username/service.git", "https://github.com/username/repo.git", "https://github.com/username/service.git"},
+		{"gitops-repo same/service repo changed", "https://github.com/username/repo.git", "https://github.com/username/service/.git", "https://github.com/username/repo.git", "https://github.com/username/service.git"},
+		{"gitops-repo changed/service repo same", "https://github.com/username/repo/.git", "https://github.com/username/service.git", "https://github.com/username/repo.git", "https://github.com/username/service.git"},
+		{"gitops-repo changed/service repo changed", "https://github.com/username/repo/.git", "https://github.com/username/service/.git", "https://github.com/username/repo.git", "https://github.com/username/service.git"},
+	}
+
+	for _, tt := range optionTests {
+		o := BootstrapParameters{
+			BootstrapOptions: &pipelines.BootstrapOptions{
+				GitOpsRepoURL:  tt.gitRepo,
+				ServiceRepoURL: tt.serviceRepo,
+			},
+		}
+		checkURLAnomalies(&o)
+
+		if o.GitOpsRepoURL != tt.wantGitopsURL && o.ServiceRepoURL != tt.wantServiceURL {
+			t.Errorf("checkURLAnomalies() got %v for gitops-repo and got %v for service-repo", o.GitOpsRepoURL, o.ServiceRepoURL)
+		}
+	}
+}
+
 func TestValidatePairFlags(t *testing.T) {
 	optionTests := []struct {
 		name          string

--- a/pkg/cmd/ui/ui.go
+++ b/pkg/cmd/ui/ui.go
@@ -17,20 +17,20 @@ import (
 
 // RepoParams struct contains the parameters required to authenticate the url with the access-token
 type RepoParams struct {
-	RepoInfo                repoInfo //holds repo specific information.
-	GitHostAccessToken      string   //holds the personal access token specefic to host-name.
-	KeyringServiceRequired  bool     //holds the value of the SaveTokenKeyring Input.
-	TokenRepoMatchCondition bool     //value is true if accessToken is valid, even if repo does not exist.
+	RepoInfo                repoInfo // holds repo specific information.
+	GitHostAccessToken      string   // holds the personal access token specefic to host-name.
+	KeyringServiceRequired  bool     // holds the value of the SaveTokenKeyring Input.
+	TokenRepoMatchCondition bool     // value is true if accessToken is valid, even if repo does not exist.
 }
 
 type repoInfo struct {
-	RepoURL      string //Stores the repo URL.
-	GitRepoValid bool   //Stores value if gitRepo is present.
+	RepoURL      string // Stores the repo URL.
+	GitRepoValid bool   // Stores value if gitRepo is present.
 }
 
 const (
-	ServiceRepoType = "service" //ServiceRepoType used to differentiate between service and gitops repo
-	GitopsRepoType  = "gitops"
+	ServiceRepoType = "service" // ServiceRepoType used to differentiate between service and gitops repo
+	GitopsRepoType  = "gitops"  // GitopsRepoType used to differentiate between service and gitops repo
 )
 
 // EnterGitRepo allows the user to specify the git repository in a prompt.

--- a/pkg/cmd/ui/ui.go
+++ b/pkg/cmd/ui/ui.go
@@ -17,21 +17,19 @@ import (
 
 // RepoParams struct contains the parameters required to authenticate the url with the access-token
 type RepoParams struct {
-	RepoInfo                repoInfo
-	GitHostAccessToken      string
-	KeyringSVC              bool
-	TokenRepoMatchCondition bool
-	TokenAuthenticated      bool
+	RepoInfo                repoInfo //holds repo specific information.
+	GitHostAccessToken      string   //holds the personal access token specefic to host-name.
+	KeyringServiceRequired  bool     //holds the value of the SaveTokenKeyring Input.
+	TokenRepoMatchCondition bool     //value is true if accessToken is valid, even if repo does not exist.
 }
 
 type repoInfo struct {
-	RepoURL      string
-	RepoType     string
-	GitRepoValid bool
+	RepoURL      string //Stores the repo URL.
+	GitRepoValid bool   //Stores value if gitRepo is present.
 }
 
 const (
-	ServiceRepoType = "service"
+	ServiceRepoType = "service" //ServiceRepoType used to differentiate between service and gitops repo
 	GitopsRepoType  = "gitops"
 )
 

--- a/pkg/cmd/ui/validate.go
+++ b/pkg/cmd/ui/validate.go
@@ -8,12 +8,17 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/openshift/odo/pkg/log"
 	"github.com/redhat-developer/kam/pkg/cmd/utility"
+	"github.com/redhat-developer/kam/pkg/pipelines/accesstoken"
 	"github.com/redhat-developer/kam/pkg/pipelines/git"
 	"github.com/redhat-developer/kam/pkg/pipelines/ioutils"
 	"github.com/redhat-developer/kam/pkg/pipelines/namespaces"
+	"github.com/zalando/go-keyring"
 	"gopkg.in/AlecAivazis/survey.v1"
 	"gopkg.in/AlecAivazis/survey.v1/terminal"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/klog"
@@ -39,16 +44,40 @@ func makeOverWriteValidator(path string) survey.Validator {
 	}
 }
 
-func makeSealedSecretsService(sealedSecretService *types.NamespacedName) survey.Validator {
+func makeSealedSecretNamespaceValidator(sealedSecretService *types.NamespacedName) survey.Validator {
+	return func(input interface{}) error {
+		return validateSealedSecretNamespace(input, sealedSecretService)
+	}
+}
+
+func makeSealedSecretServiceValidator(sealedSecretService *types.NamespacedName) survey.Validator {
 	return func(input interface{}) error {
 		return validateSealedSecretService(input, sealedSecretService)
 	}
 }
 
-func makeAccessTokenCheck(serviceRepo string) survey.Validator {
-	return func(input interface{}) error {
-		return ValidateAccessToken(input, serviceRepo)
+// SetAccessToken validates the access  token and the sets/retrieves the value from the keyring based on the situation.
+func SetAccessToken(io *RepoParams) error {
+	if io.GitHostAccessToken != "" {
+		err := ValidateAccessToken(io)
+		if err != nil {
+			return err
+		}
 	}
+	if io.KeyringSVC {
+		err := accesstoken.SetAccessToken(io.RepoInfo.RepoURL, io.GitHostAccessToken)
+		if err != nil {
+			return err
+		}
+	}
+	if io.GitHostAccessToken == "" {
+		secret, err := accesstoken.GetAccessToken(io.RepoInfo.RepoURL)
+		if err != nil {
+			return fmt.Errorf("unable to use access-token from keyring/env-var: %v, please pass a valid token to --git-host-access-token", err)
+		}
+		io.GitHostAccessToken = secret
+	}
+	return nil
 }
 
 // ValidatePrefix checks the length of the prefix with the env crosses 63 chars or not
@@ -109,25 +138,46 @@ func validateOverwriteOption(input interface{}, path string) error {
 }
 
 // ValidateAccessToken validates if the access token is correct for a particular service repo
-func ValidateAccessToken(input interface{}, serviceRepo string) error {
+func ValidateAccessToken(io *RepoParams) error {
+	repo, err := git.NewRepository(io.RepoInfo.RepoURL, io.GitHostAccessToken)
+	if err != nil {
+		return err
+	}
+	parsedURL, err := url.Parse(io.RepoInfo.RepoURL)
+	if err != nil {
+		return fmt.Errorf("failed to parse the provided URL %q: %w", io.RepoInfo.RepoURL, err)
+	}
+	repoName, err := git.GetRepoName(parsedURL)
+	if err != nil {
+		return fmt.Errorf("failed to get the repository name from %q: %w", io.RepoInfo.RepoURL, err)
+	}
+	_, res, err := repo.Client.Repositories.Find(context.Background(), repoName)
+	if err != nil && res.Status == 401 {
+		return apierrors.NewForbidden(schema.GroupResource{}, "", fmt.Errorf("Invalid access token, unable to authenticate client for repo: %s", io.RepoInfo.RepoURL))
+	}
+	if err != nil && res.Status == 404 {
+		log.Warningf("Note: The git repo %v cannot be found, usually occurs when the repository does not exist", io.RepoInfo.RepoURL)
+		io.RepoInfo.GitRepoValid = false
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// validateSealedSecretService validates to see if the sealed secret service is present in the correct namespace.
+func validateSealedSecretNamespace(input interface{}, sealedSecretService *types.NamespacedName) error {
 	if s, ok := input.(string); ok {
-		repo, err := git.NewRepository(serviceRepo, s)
+		clientSet, err := namespaces.GetClientSet()
 		if err != nil {
 			return err
 		}
-		parsedURL, err := url.Parse(serviceRepo)
-		if err != nil {
-			return fmt.Errorf("failed to parse the provided URL %q: %w", serviceRepo, err)
+		exists, _ := namespaces.Exists(clientSet, s)
+		if !exists {
+			return fmt.Errorf("The namespace %s is not found on the cluster", s)
 		}
-		repoName, err := git.GetRepoName(parsedURL)
-		if err != nil {
-			return fmt.Errorf("failed to get the repository name from %q: %w", serviceRepo, err)
-		}
-		_, _, err = repo.Client.Repositories.Find(context.Background(), repoName)
-		if err != nil {
-			return fmt.Errorf("The token passed is incorrect for repository %s", repoName)
-		}
-		return nil
+		sealedSecretService.Namespace = s
 	}
 	return nil
 }
@@ -139,21 +189,34 @@ func validateSealedSecretService(input interface{}, sealedSecretService *types.N
 		if err != nil {
 			return err
 		}
-		clientSet, err := namespaces.GetClientSet()
-		if err != nil {
-			return err
-		}
-		exists, _ := namespaces.Exists(clientSet, s)
-		if !exists {
-			return fmt.Errorf("The namespace %s is not found on the cluster", s)
-		}
-		sealedSecretService.Namespace = s
-		sealedSecretService.Name = enterSealedSecretService()
+		sealedSecretService.Name = s
 		return client.CheckIfSealedSecretsExists(*sealedSecretService)
 	}
 	return nil
 }
 
+func validateRepoTokenCreds(repoParams *RepoParams) error {
+	secret, err := accesstoken.GetAccessToken(repoParams.RepoInfo.RepoURL)
+	if err != nil && err != keyring.ErrNotFound {
+		return err
+	}
+	if secret == "" && !repoParams.TokenAuthenticated {
+		token, err := EnterGitHostAccessToken(repoParams.RepoInfo.RepoURL)
+		repoParams.GitHostAccessToken = token
+		repoParams.KeyringSVC = UseKeyringRingSvc()
+		err = SetAccessToken(repoParams)
+		if err != nil {
+			return err
+		}
+	} else {
+		err := ValidateAccessToken(repoParams)
+		if err != nil {
+			return err
+		}
+		repoParams.GitHostAccessToken = secret
+	}
+	return nil
+}
 func checkSecretLength(secret string) bool {
 	if secret != "" {
 		if len(secret) < minSecretLen {

--- a/pkg/cmd/ui/validate.go
+++ b/pkg/cmd/ui/validate.go
@@ -64,7 +64,7 @@ func SetAccessToken(io *RepoParams) error {
 			return err
 		}
 	}
-	if io.KeyringSVC {
+	if io.KeyringServiceRequired {
 		err := accesstoken.SetAccessToken(io.RepoInfo.RepoURL, io.GitHostAccessToken)
 		if err != nil {
 			return err
@@ -200,10 +200,10 @@ func validateRepoTokenCreds(repoParams *RepoParams) error {
 	if err != nil && err != keyring.ErrNotFound {
 		return err
 	}
-	if secret == "" && !repoParams.TokenAuthenticated {
+	if secret == "" {
 		token, err := EnterGitHostAccessToken(repoParams.RepoInfo.RepoURL)
 		repoParams.GitHostAccessToken = token
-		repoParams.KeyringSVC = UseKeyringRingSvc()
+		repoParams.KeyringServiceRequired = UseKeyringRingSvc()
 		err = SetAccessToken(repoParams)
 		if err != nil {
 			return err

--- a/pkg/pipelines/git/repository.go
+++ b/pkg/pipelines/git/repository.go
@@ -96,12 +96,12 @@ func GetRepoName(u *url.URL) (string, error) {
 			components = append(components, s)
 		}
 	}
-	if len(components) != 2 {
+	if len(components) != 2 && components[2] != ".git" {
 		return "", errors.New("failed to get Git repo: " + u.Path)
 	}
 	components[1] = strings.TrimSuffix(components[1], ".git")
-	for _, s := range components {
-		if strings.Contains(s, ".") {
+	for i := 0; i < 2; i++ {
+		if strings.Contains(components[i], ".") {
 			return "", errors.New("failed to get Git repo: " + u.Path)
 		}
 	}

--- a/pkg/pipelines/git/repository_test.go
+++ b/pkg/pipelines/git/repository_test.go
@@ -1,6 +1,7 @@
 package git
 
 import (
+	"net/url"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -149,5 +150,33 @@ func TestCreateWebHook(t *testing.T) {
 
 	if created != "1" {
 		t.Errorf("failed to create webhook, got %q, want %q", created, "1")
+	}
+}
+
+func TestExtractRepo(t *testing.T) {
+	Tests := []struct {
+		desc     string
+		argument string
+		want     string
+	}{
+		{"Standard url",
+			"https://github.com/username/repo.git",
+			`username/repo`},
+		{"Standard url",
+			"https://github.com/username/repo/.git",
+			`username/repo`},
+	}
+	for _, tt := range Tests {
+		parsedURL, err := url.Parse(tt.argument)
+		if err != nil {
+			t.Error(err)
+		}
+		got, err := GetRepoName(parsedURL)
+		if err != nil {
+			t.Error(err)
+		}
+		if got != tt.want {
+			t.Errorf("Expected %s but got %s", tt.want, got)
+		}
 	}
 }


### PR DESCRIPTION
**What type of PR is this?**
> /kind cleanup

**What does this PR do / why we need it**:

The follwing url :https://github.com/username/repo/.git leads to an error although its an acceptable url. There can be many such anomalies. This PR validates the users input with the git client and throws an error in the event of a failed authentication.

The differentiation is done based on the response from the server, if the git repo is not found the user is warned of its absence and is later asked if he wishes to push/create repo.

If the git host access token is invalid the user is prompted for the url and the host token again, incorrect tokens will error out in non-interactive mode.

The url https://github.com/username/repo/.git will then be validated to  https://github.com/username/repo.git in the command layer.

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [] Documentation has been updated.

Current implementation might not need documentation fixes since its an improvement of current implementation.

**Which issue(s) this PR fixes**:
https://issues.redhat.com/browse/GITOPS-492

