### PR TITLE
Add app labels to applications

### DIFF
--- a/pkg/pipelines/argocd/argocd.go
+++ b/pkg/pipelines/argocd/argocd.go
@@ -16,10 +16,7 @@ import (
 	res "github.com/redhat-developer/kam/pkg/pipelines/resources"
 )
 
-const (
-	vcsSourceLabel = "app.openshift.io/vcs-source"
-	appLabel       = "app.kubernetes.io/name"
-)
+const appLabel = "app.kubernetes.io/name"
 
 var (
 	applicationTypeMeta = meta.TypeMeta(

--- a/pkg/pipelines/argocd/argocd_test.go
+++ b/pkg/pipelines/argocd/argocd_test.go
@@ -58,8 +58,10 @@ func TestBuildCreatesArgoCD(t *testing.T) {
 
 	want := res.Resources{
 		"config/argocd/test-dev-env-app.yaml": &argoappv1.Application{
-			TypeMeta:   applicationTypeMeta,
-			ObjectMeta: meta.ObjectMeta(meta.NamespacedName(ArgoCDNamespace, "test-dev-env")),
+			TypeMeta: applicationTypeMeta,
+			ObjectMeta: meta.ObjectMeta(meta.NamespacedName(
+				ArgoCDNamespace, "test-dev-env"),
+			),
 			Spec: argoappv1.ApplicationSpec{
 				Source: argoappv1.ApplicationSource{
 					RepoURL: testRepoURL,
@@ -74,8 +76,13 @@ func TestBuildCreatesArgoCD(t *testing.T) {
 			},
 		},
 		"config/argocd/test-dev-http-api-app.yaml": &argoappv1.Application{
-			TypeMeta:   applicationTypeMeta,
-			ObjectMeta: meta.ObjectMeta(meta.NamespacedName(ArgoCDNamespace, "test-dev-http-api")),
+			TypeMeta: applicationTypeMeta,
+			ObjectMeta: meta.ObjectMeta(
+				meta.NamespacedName(ArgoCDNamespace, "test-dev-http-api"),
+				meta.AddLabels(map[string]string{
+					appLabel: "http-api",
+				}),
+			),
 			Spec: argoappv1.ApplicationSpec{
 				Source: argoappv1.ApplicationSource{
 					RepoURL: testRepoURL,
@@ -219,8 +226,13 @@ func TestBuildWithRepoConfig(t *testing.T) {
 			},
 		},
 		"config/argocd/test-production-prod-api-app.yaml": &argoappv1.Application{
-			TypeMeta:   applicationTypeMeta,
-			ObjectMeta: meta.ObjectMeta(meta.NamespacedName(ArgoCDNamespace, "test-production-prod-api")),
+			TypeMeta: applicationTypeMeta,
+			ObjectMeta: meta.ObjectMeta(
+				meta.NamespacedName(ArgoCDNamespace, "test-production-prod-api"),
+				meta.AddLabels(map[string]string{
+					appLabel: "prod-api",
+				}),
+			),
 			Spec: argoappv1.ApplicationSpec{
 				Source: *makeAppSource(prodEnv, prodEnv.Apps[0], testRepoURL),
 				Destination: argoappv1.ApplicationDestination{
@@ -273,8 +285,10 @@ func TestBuildAddsClusterToApp(t *testing.T) {
 
 	want := res.Resources{
 		"config/argocd/test-dev-env-app.yaml": &argoappv1.Application{
-			TypeMeta:   applicationTypeMeta,
-			ObjectMeta: meta.ObjectMeta(meta.NamespacedName(ArgoCDNamespace, "test-dev-env")),
+			TypeMeta: applicationTypeMeta,
+			ObjectMeta: meta.ObjectMeta(
+				meta.NamespacedName(ArgoCDNamespace, "test-dev-env"),
+			),
 			Spec: argoappv1.ApplicationSpec{
 				Source: *makeEnvSource(testEnv, testRepoURL),
 				Destination: argoappv1.ApplicationDestination{
@@ -286,8 +300,13 @@ func TestBuildAddsClusterToApp(t *testing.T) {
 			},
 		},
 		"config/argocd/test-dev-http-api-app.yaml": &argoappv1.Application{
-			TypeMeta:   applicationTypeMeta,
-			ObjectMeta: meta.ObjectMeta(meta.NamespacedName(ArgoCDNamespace, "test-dev-http-api")),
+			TypeMeta: applicationTypeMeta,
+			ObjectMeta: meta.ObjectMeta(
+				meta.NamespacedName(ArgoCDNamespace, "test-dev-http-api"),
+				meta.AddLabels(map[string]string{
+					appLabel: "http-api",
+				}),
+			),
 			Spec: argoappv1.ApplicationSpec{
 				Source: *makeAppSource(testEnv, testEnv.Apps[0], testRepoURL),
 				Destination: argoappv1.ApplicationDestination{

--- a/pkg/pipelines/bootstrap_test.go
+++ b/pkg/pipelines/bootstrap_test.go
@@ -57,6 +57,7 @@ func TestBootstrapManifest(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+
 	want := res.Resources{
 		"config/tst-cicd/base/03-secrets/webhook-secret-tst-dev-http-api.yaml": hookSecret,
 		"environments/tst-dev/apps/app-http-api/services/http-api/base/config/100-deployment.yaml": deployment.Create(

--- a/pkg/pipelines/environments/environments_test.go
+++ b/pkg/pipelines/environments/environments_test.go
@@ -30,7 +30,11 @@ func TestBuildEnvironmentFilesWithAppsToEnvironment(t *testing.T) {
 				"../services/service-metrics",
 			},
 		},
-		"environments/test-dev/apps/my-app-1/kustomization.yaml":                                   &res.Kustomization{Bases: []string{"overlays"}},
+		"environments/test-dev/apps/my-app-1/kustomization.yaml": &res.Kustomization{
+			Bases: []string{"overlays"},
+			CommonLabels: map[string]string{
+				vcsSourceLabel: "example/example",
+			}},
 		"environments/test-dev/apps/my-app-1/overlays/kustomization.yaml":                          &res.Kustomization{Bases: []string{"../base"}},
 		"environments/test-dev/env/base/test-dev-environment.yaml":                                 namespaces.Create("test-dev", testGitOpsRepoURL),
 		"environments/test-dev/env/base/test-dev-rolebinding.yaml":                                 createRoleBinding(m.Environments[0], "cicd", "pipelines"),
@@ -64,7 +68,12 @@ func TestBuildEnvironmentFilesWithEnvironmentsToApps(t *testing.T) {
 				"../services/service-metrics",
 			},
 		},
-		"environments/test-dev/apps/my-app-1/kustomization.yaml":          &res.Kustomization{Bases: []string{"overlays"}},
+		"environments/test-dev/apps/my-app-1/kustomization.yaml": &res.Kustomization{
+			Bases: []string{"overlays"},
+			CommonLabels: map[string]string{
+				vcsSourceLabel: "example/example",
+			},
+		},
 		"environments/test-dev/apps/my-app-1/overlays/kustomization.yaml": &res.Kustomization{Bases: []string{"../base"}},
 		"environments/test-dev/env/base/test-dev-environment.yaml":        namespaces.Create("test-dev", testGitOpsRepoURL),
 		"environments/test-dev/env/base/test-dev-rolebinding.yaml":        createRoleBinding(m.Environments[0], "cicd", "pipelines"),
@@ -172,7 +181,12 @@ func TestBuildEnvironmentFilesWithNoCICDEnv(t *testing.T) {
 				"../services/service-metrics",
 			},
 		},
-		"environments/test-dev/apps/my-app-1/kustomization.yaml":                                   &res.Kustomization{Bases: []string{"overlays"}},
+		"environments/test-dev/apps/my-app-1/kustomization.yaml": &res.Kustomization{
+			Bases: []string{"overlays"},
+			CommonLabels: map[string]string{
+				vcsSourceLabel: "example/example",
+			},
+		},
 		"environments/test-dev/apps/my-app-1/overlays/kustomization.yaml":                          &res.Kustomization{Bases: []string{"../base"}},
 		"environments/test-dev/env/base/test-dev-environment.yaml":                                 namespaces.Create("test-dev", testGitOpsRepoURL),
 		"environments/test-dev/env/base/kustomization.yaml":                                        &res.Kustomization{Resources: []string{"test-dev-environment.yaml"}},

--- a/pkg/pipelines/resources/kustomization.go
+++ b/pkg/pipelines/resources/kustomization.go
@@ -2,6 +2,7 @@ package resources
 
 // Kustomization is a structural representation of the Kustomize file format.
 type Kustomization struct {
-	Resources []string `json:"resources,omitempty"`
-	Bases     []string `json:"bases,omitempty"`
+	Resources    []string          `json:"resources,omitempty"`
+	Bases        []string          `json:"bases,omitempty"`
+	CommonLabels map[string]string `json:"commonLabels,omitempty"`
 }

--- a/pkg/pipelines/service_test.go
+++ b/pkg/pipelines/service_test.go
@@ -36,10 +36,15 @@ func TestServiceResourcesWithCICD(t *testing.T) {
 	assertNoError(t, err)
 
 	want := res.Resources{
-		"config/cicd/base/03-secrets/webhook-secret-test-dev-test.yaml":   hookSecret,
-		"environments/test-dev/apps/test-app/base/kustomization.yaml":     &res.Kustomization{Bases: []string{"../services/test-svc", "../services/test"}},
-		"environments/test-dev/apps/test-app/kustomization.yaml":          &res.Kustomization{Bases: []string{"overlays"}},
-		"environments/test-dev/apps/test-app/overlays/kustomization.yaml": &res.Kustomization{Bases: []string{"../base"}},
+		"config/cicd/base/03-secrets/webhook-secret-test-dev-test.yaml": hookSecret,
+		"environments/test-dev/apps/test-app/base/kustomization.yaml": &res.Kustomization{
+			Bases: []string{"../services/test-svc", "../services/test"}},
+		"environments/test-dev/apps/test-app/kustomization.yaml": &res.Kustomization{
+			Bases:        []string{"overlays"},
+			CommonLabels: map[string]string{"app.openshift.io/vcs-source": "org/test"},
+		},
+		"environments/test-dev/apps/test-app/overlays/kustomization.yaml": &res.Kustomization{
+			Bases: []string{"../base"}},
 		"pipelines.yaml": &config.Manifest{
 			Config: &config.Config{
 				Pipelines: &config.PipelinesConfig{
@@ -111,8 +116,13 @@ func TestServiceResourcesWithArgoCD(t *testing.T) {
 				"../services/test",
 			},
 		},
-		"environments/test-dev/apps/test-app/kustomization.yaml":          &res.Kustomization{Bases: []string{"overlays"}},
-		"environments/test-dev/apps/test-app/overlays/kustomization.yaml": &res.Kustomization{Bases: []string{"../base"}},
+		"environments/test-dev/apps/test-app/kustomization.yaml": &res.Kustomization{
+			Bases:        []string{"overlays"},
+			CommonLabels: map[string]string{"app.openshift.io/vcs-source": "org/test"},
+		},
+		"environments/test-dev/apps/test-app/overlays/kustomization.yaml": &res.Kustomization{
+			Bases: []string{"../base"},
+		},
 		"pipelines.yaml": &config.Manifest{
 			Config: &config.Config{
 				ArgoCD: &config.ArgoCDConfig{
@@ -164,10 +174,19 @@ func TestServiceResourcesWithoutArgoCD(t *testing.T) {
 	fakeFs := ioutils.NewMemoryFilesystem()
 	m := buildManifest(false, false)
 	want := res.Resources{
-		"environments/test-dev/apps/test-app/base/kustomization.yaml":     &res.Kustomization{Bases: []string{"../services/test-svc", "../services/test"}},
-		"environments/test-dev/apps/test-app/kustomization.yaml":          &res.Kustomization{Bases: []string{"overlays"}},
-		"environments/test-dev/apps/test-app/overlays/kustomization.yaml": &res.Kustomization{Bases: []string{"../base"}},
-		"environments/test-dev/env/base/kustomization.yaml":               &res.Kustomization{Resources: []string{"test-dev-environment.yaml"}, Bases: []string{"../../apps/test-app/overlays"}},
+		"environments/test-dev/apps/test-app/base/kustomization.yaml": &res.Kustomization{
+
+			Bases: []string{"../services/test-svc", "../services/test"}},
+		"environments/test-dev/apps/test-app/kustomization.yaml": &res.Kustomization{
+			Bases:        []string{"overlays"},
+			CommonLabels: map[string]string{"app.openshift.io/vcs-source": "org/test"},
+		},
+		"environments/test-dev/apps/test-app/overlays/kustomization.yaml": &res.Kustomization{
+			Bases: []string{"../base"}},
+		"environments/test-dev/env/base/kustomization.yaml": &res.Kustomization{
+			Resources: []string{"test-dev-environment.yaml"},
+			Bases:     []string{"../../apps/test-app/overlays"},
+		},
 		"pipelines.yaml": &config.Manifest{
 			GitOpsURL: "http://github.com/org/test",
 			Environments: []*config.Environment{
@@ -214,9 +233,12 @@ func TestAddServiceWithoutApp(t *testing.T) {
 	fakeFs := ioutils.NewMemoryFilesystem()
 	m := buildManifest(false, false)
 	want := res.Resources{
-		"environments/test-dev/apps/new-app/base/kustomization.yaml":                        &res.Kustomization{Bases: []string{"../services/test"}},
-		"environments/test-dev/apps/new-app/overlays/kustomization.yaml":                    &res.Kustomization{Bases: []string{"../base"}},
-		"environments/test-dev/apps/new-app/kustomization.yaml":                             &res.Kustomization{Bases: []string{"overlays"}},
+		"environments/test-dev/apps/new-app/base/kustomization.yaml":     &res.Kustomization{Bases: []string{"../services/test"}},
+		"environments/test-dev/apps/new-app/overlays/kustomization.yaml": &res.Kustomization{Bases: []string{"../base"}},
+		"environments/test-dev/apps/new-app/kustomization.yaml": &res.Kustomization{
+			Bases:        []string{"overlays"},
+			CommonLabels: map[string]string{"app.openshift.io/vcs-source": "org/test"},
+		},
 		"environments/test-dev/apps/new-app/services/test/base/kustomization.yaml":          &res.Kustomization{Bases: []string{"./config"}},
 		"environments/test-dev/apps/new-app/services/test/kustomization.yaml":               &res.Kustomization{Bases: []string{"overlays"}},
 		"environments/test-dev/apps/new-app/services/test/overlays/kustomization.yaml":      &res.Kustomization{Bases: []string{"../base"}},


### PR DESCRIPTION
**What type of PR is this?**
> /kind enhancement

**What does this PR do / why we need it**:

It adds two labels to objects that are created

"app.openshift.io/vcs-source" to all objects that are created, with a value that is the "fullname" of the GitOps Repo.

"app.kubernetes.io/name" is added to all ArgoCD Application objects, with the source application that they come from.

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:
