### PR TITLE
[WIP] GITOPS-513: fix for sealed secret service name and namespace overlap

### DIFF
--- a/pkg/cmd/ui/ui.go
+++ b/pkg/cmd/ui/ui.go
@@ -135,6 +135,7 @@ func enterSealedSecretService() string {
 // EnterSealedSecretService , prompts the UI to ask for the sealed-secrets-namespaces
 func EnterSealedSecretService(sealedSecretService *types.NamespacedName) string {
 	var sealedNs string
+	sealedSecretService.Name = enterSealedSecretService()
 	prompt := &survey.Input{
 		Message: "Provide a namespace in which the Sealed Secrets operator is installed, automatically generated secrets are encrypted with this operator?",
 		Help:    "If you have a custom installation of the Sealed Secrets operator, we need to know how to communicate with it to seal your secrets",

--- a/pkg/cmd/ui/validate.go
+++ b/pkg/cmd/ui/validate.go
@@ -148,7 +148,6 @@ func validateSealedSecretService(input interface{}, sealedSecretService *types.N
 			return fmt.Errorf("The namespace %s is not found on the cluster", s)
 		}
 		sealedSecretService.Namespace = s
-		sealedSecretService.Name = enterSealedSecretService()
 		return client.CheckIfSealedSecretsExists(*sealedSecretService)
 	}
 	return nil


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What does this PR do / why we need it**:
This PR would fix the bug GITOPS-513, where there is a query within a query. i.e. It queries for SealedSecretServiceName within the SealedSecretServiceNamespace query and hence the overlap. This PR fixes that by first querying the SealedSecretServiceName and then using that value as part of validator func for SealedSecretServiceNamespace query. 

**Have you updated the necessary documentation?**

Documentation update is not required by this PR.

**Which issue(s) this PR fixes**:

Fixes https://issues.redhat.com/browse/GITOPS-513

**How to test changes / Special notes to the reviewer**:
