### PR TITLE
Improve sealedsecret namespace

### DIFF
--- a/pkg/cmd/bootstrap.go
+++ b/pkg/cmd/bootstrap.go
@@ -227,8 +227,8 @@ func checkBootstrapDependencies(io *BootstrapParameters, client *utility.Client,
 	if err := client.CheckIfSealedSecretsExists(defaultSealedSecretsServiceName); err != nil {
 
 		// in case Sealed Secret namespace/service name are provided, try them too
-		if (len(io.BootstrapOptions.SealedSecretsService.Namespace) > 0 && io.BootstrapOptions.SealedSecretsService.Namespace != defaultSealedSecretsServiceName.Namespace) ||
-			(len(io.BootstrapOptions.SealedSecretsService.Name) > 0 && (io.BootstrapOptions.SealedSecretsService.Name != defaultSealedSecretsServiceName.Name)) {
+		if (io.BootstrapOptions.SealedSecretsService.Namespace != "" && io.BootstrapOptions.SealedSecretsService.Namespace != defaultSealedSecretsServiceName.Namespace) ||
+			(io.BootstrapOptions.SealedSecretsService.Name != "" && (io.BootstrapOptions.SealedSecretsService.Name != defaultSealedSecretsServiceName.Name)) {
 
 			if err := client.CheckIfSealedSecretsExists(io.BootstrapOptions.SealedSecretsService); err != nil {
 				warnIfNotFound(spinner, "Provided Sealed Secrets namespace/name are not valid. Please verify", err)

--- a/pkg/cmd/bootstrap_test.go
+++ b/pkg/cmd/bootstrap_test.go
@@ -37,7 +37,7 @@ const (
 
 const (
 	customSealedSecretsNS         = "sealed-secrets"
-	customSealedSecretsController = "cutom-sealed-secrets-controller"
+	customSealedSecretsController = "custom-sealed-secrets-controller"
 )
 
 func TestValidatePrefix(t *testing.T) {

--- a/pkg/cmd/bootstrap_test.go
+++ b/pkg/cmd/bootstrap_test.go
@@ -380,7 +380,7 @@ Checking if OpenShift Pipelines Operator is installed with the default configura
 
 func TestDependenciesWithAllInstalledCustomSealedSecretsServiceButNotMatched(t *testing.T) {
 	// use an OTHER sealed secret service
-	fakeClient := newFakeClient([]runtime.Object{customSealedSecretsService2(), pipelinesOperator()}, []runtime.Object{argoCDCSV()})
+	fakeClient := newFakeClient([]runtime.Object{customSealedSecretsServiceOther(), pipelinesOperator()}, []runtime.Object{argoCDCSV()})
 
 	wantMsg := `
 Checking if Sealed Secrets is installed with the default configuration [Provided Sealed Secrets namespace/name are not valid. Please verify]
@@ -473,7 +473,7 @@ func customSealedSecretsService() *corev1.Service {
 	}
 }
 
-func customSealedSecretsService2() *corev1.Service {
+func customSealedSecretsServiceOther() *corev1.Service {
 	return &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "dummy-controller-do-not-use-value",


### PR DESCRIPTION
**What type of PR is this?**
/kind enhancement


**What does this PR do / why we need it**:
In the bootstrap use case does the checkDependency logic does not take into account if the user provide custom values for SealedSecrets (service-name, namespace). This results in wrong info in the spinner and let the impression that something is wrong during bootstrap.

This enhancement is necessary, because the SealedSecrets Operator in OpenShift is installed in other namespace (not `cicd`)

**Have you updated the necessary documentation?**
No docu update necessary

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:
n/a
Fixes #?

**How to test changes / Special notes to the reviewer**:

* Test boostrap with the parameters `--sealed-secrets-ns` and `--sealed-secrets-svc`

```
dist/kam_darwin_amd64 bootstrap \
  --service-repo-url https://github.com/k8s-universe/tekton-101 \
  --gitops-repo-url https://github.com/k8s-universe/tekton-101-gitops.git \
  --image-repo image-registry-openshift-image-registry.apps.cluster-608e.sandbox1691.opentlc.com/demo-tekton-gitops \
  --git-host-access-token 8234db.... \
  --output . \
  --push-to-git=false \
  --sealed-secrets-ns=sealed-secrets \
  --sealed-secrets-svc=sealed-secrets-controller


Checking dependencies

 ✓  Checking if Sealed Secrets is installed with the default configuration [160ms]
 ✓  Checking if ArgoCD Operator is installed with the default configuration [343ms]
 ✓  Checking if OpenShift Pipelines Operator is installed with the default configuration [373ms]
Adding .git to https://github.com/k8s-universe/tekton-101

Completing Bootstrap process

 ✓  Authentication tokens encrypted in secrets
 ✓  Pipelines tracker has been configured
 ✓  OpenShift Pipelines resources created
 ✓  Openshift Route for EventListener created
 ✓  Created dev, stage and CICD environments
 ✓  Bootstrapped OpenShift resources successfully

 Next Steps:
 Please refer to https://github.com/redhat-developer/kam/tree/master/docs to get started.
```

Verify also the updated test cases.