### PR TITLE
Do not merge: Smart default for bootstrap options except for point 5 of the epic; Fix 147

### DIFF
--- a/docs/commands/kam_bootstrap.md
+++ b/docs/commands/kam_bootstrap.md
@@ -27,7 +27,8 @@ kam bootstrap [flags]
       --gitops-webhook-secret string    Provide a secret that we can use to authenticate incoming hooks from your Git hosting service for the GitOps repository. (if not provided, it will be auto-generated)
   -h, --help                            help for bootstrap
       --image-repo string               Image repository of the form <registry>/<username>/<repository> or <project>/<app> which is used to push newly built images
-      --output string                   Path to write GitOps resources (default ".")
+      --interactive                     If true, enable prompting for most options if not already specified on the command line
+      --output string                   Path to write GitOps resources (default "./gitops")
       --overwrite                       Overwrites previously existing GitOps configuration (if any) on the local filesystem
   -p, --prefix string                   Add a prefix to the environment names(Dev, stage,prod,cicd etc.) to distinguish and identify individual environments
       --private-repo-driver string      If your Git repositories are on a custom domain, please indicate which driver to use github or gitlab

--- a/pkg/cmd/bootstrap.go
+++ b/pkg/cmd/bootstrap.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"errors"
 	"fmt"
+	"github.com/redhat-developer/kam/pkg/pipelines/imagerepo"
 	"net/url"
 	"os"
 	"strings"
@@ -71,7 +72,8 @@ var (
 // BootstrapParameters encapsulates the parameters for the kam pipelines init command.
 type BootstrapParameters struct {
 	*pipelines.BootstrapOptions
-	PushToGit bool // records whether or not the repository should be pushed to git.
+	PushToGit   bool // records whether or not the repository should be pushed to git.
+	Interactive bool
 }
 
 type status interface {
@@ -108,9 +110,10 @@ func (io *BootstrapParameters) Complete(name string, cmd *cobra.Command, args []
 		return err
 	}
 
-	if cmd.Flags().NFlag() == 0 {
-		return initiateInteractiveMode(io, client)
+	if cmd.Flags().NFlag() == 0 || cmd.Flag("interactive").Changed {
+		return initiateInteractiveMode(io, client, cmd)
 	}
+
 	addGitURLSuffixIfNecessary(io)
 	return nonInteractiveMode(io, client)
 }
@@ -122,7 +125,7 @@ func addGitURLSuffixIfNecessary(io *BootstrapParameters) {
 
 // nonInteractiveMode gets triggered if a flag is passed, checks for mandatory flags.
 func nonInteractiveMode(io *BootstrapParameters, client *utility.Client) error {
-	mandatoryFlags := map[string]string{serviceRepoURLFlag: io.ServiceRepoURL, gitopsRepoURLFlag: io.GitOpsRepoURL, imageRepoFlag: io.ImageRepo}
+	mandatoryFlags := map[string]string{serviceRepoURLFlag: io.ServiceRepoURL, gitopsRepoURLFlag: io.GitOpsRepoURL}
 	if err := checkMandatoryFlags(mandatoryFlags); err != nil {
 		return err
 	}
@@ -135,7 +138,7 @@ func nonInteractiveMode(io *BootstrapParameters, client *utility.Client) error {
 
 func checkMandatoryFlags(flags map[string]string) error {
 	missingFlags := []string{}
-	mandatoryFlags := []string{serviceRepoURLFlag, gitopsRepoURLFlag, imageRepoFlag}
+	mandatoryFlags := []string{serviceRepoURLFlag, gitopsRepoURLFlag}
 	for _, flag := range mandatoryFlags {
 		if flags[flag] == "" {
 			missingFlags = append(missingFlags, fmt.Sprintf("%q", flag))
@@ -152,13 +155,18 @@ func missingFlagErr(flags []string) error {
 }
 
 // initiateInteractiveMode starts the interactive mode impplementation if no flags are passed.
-func initiateInteractiveMode(io *BootstrapParameters, client *utility.Client) error {
+func initiateInteractiveMode(io *BootstrapParameters, client *utility.Client, cmd *cobra.Command) error {
 	log.Progressf("\nStarting interactive prompt\n")
+	// Prompt if user wants to use all default values and only be prompted with required or other necessary questions
+	promptForAll := !ui.UseDefaultValues()
 	// ask for sealed secrets only when default is absent
 	if client.CheckIfSealedSecretsExists(defaultSealedSecretsServiceName) != nil {
 		io.SealedSecretsService.Namespace = ui.EnterSealedSecretService(&io.SealedSecretsService)
 	}
-	io.GitOpsRepoURL = utility.AddGitSuffixIfNecessary(ui.EnterGitRepo())
+	if io.GitOpsRepoURL == "" {
+		io.GitOpsRepoURL = ui.EnterGitRepo()
+	}
+	io.GitOpsRepoURL = utility.AddGitSuffixIfNecessary(io.GitOpsRepoURL)
 	if !isKnownDriver(io.GitOpsRepoURL) {
 		io.PrivateRepoDriver = ui.SelectPrivateRepoDriver()
 		host, err := accesstoken.HostFromURL(io.GitOpsRepoURL)
@@ -168,32 +176,80 @@ func initiateInteractiveMode(io *BootstrapParameters, client *utility.Client) er
 		identifier := factory.NewDriverIdentifier(factory.Mapping(host, io.PrivateRepoDriver))
 		factory.DefaultIdentifier = identifier
 	}
-	if ui.UseInternalRegistry() {
-		io.ImageRepo = ui.EnterImageRepoInternalRegistry()
-	} else {
-		io.ImageRepo = ui.EnterImageRepoExternalRepository()
-		io.DockerConfigJSONFilename = ui.EnterDockercfg()
+	if io.ImageRepo != "" {
+		isInternalRegistry, _, err := imagerepo.ValidateImageRepo(io.ImageRepo)
+		if !isInternalRegistry {
+			if !cmd.Flag("dockercfgjson").Changed {
+				log.Progressf("The supplied image repository has been detected as an external repository.")
+				io.DockerConfigJSONFilename = ui.EnterDockercfg()
+			}
+		}
+		if err != nil {
+			return err
+		}
+	} else if promptForAll {
+		if ui.UseInternalRegistry() {
+			io.ImageRepo = ui.EnterImageRepoInternalRegistry()
+		} else {
+			io.ImageRepo = ui.EnterImageRepoExternalRepository()
+			io.DockerConfigJSONFilename = ui.EnterDockercfg()
+		}
 	}
-	io.GitOpsWebhookSecret = ui.EnterGitWebhookSecret(io.GitOpsRepoURL)
-	io.ServiceRepoURL = utility.AddGitSuffixIfNecessary(ui.EnterServiceRepoURL())
-	io.ServiceWebhookSecret = ui.EnterGitWebhookSecret(io.ServiceRepoURL)
+	if promptForAll {
+		io.GitOpsWebhookSecret = ui.EnterGitWebhookSecret(io.GitOpsRepoURL)
+	}
+	if io.ServiceRepoURL == "" {
+		io.ServiceRepoURL = ui.EnterServiceRepoURL()
+	}
+	io.ServiceRepoURL = utility.AddGitSuffixIfNecessary(io.ServiceRepoURL)
+	if promptForAll {
+		io.ServiceWebhookSecret = ui.EnterGitWebhookSecret(io.ServiceRepoURL)
+	}
 	secret, err := accesstoken.GetAccessToken(io.ServiceRepoURL)
 	if err != nil && err != keyring.ErrNotFound {
 		return err
 	}
-	if secret == "" {
-		io.GitHostAccessToken = ui.EnterGitHostAccessToken(io.ServiceRepoURL)
-		io.SaveTokenKeyRing = ui.UseKeyringRingSvc()
+	if secret == "" { // We must prompt for the token
+		if io.GitHostAccessToken == "" {
+			io.GitHostAccessToken = ui.EnterGitHostAccessToken(io.ServiceRepoURL)
+		}
+		if !cmd.Flag("save-token-keyring").Changed {
+			io.SaveTokenKeyRing = ui.UseKeyringRingSvc()
+		}
 		setAccessToken(io)
 	} else {
 		io.GitHostAccessToken = secret
 	}
-	io.CommitStatusTracker = ui.SetupCommitStatusTracker()
-	io.PushToGit = ui.SelectOptionPushToGit()
-	io.Prefix = ui.EnterPrefix()
-	io.OutputPath = ui.EnterOutputPath()
+	if !cmd.Flag("commit-status-tracker").Changed && promptForAll {
+		io.CommitStatusTracker = ui.SetupCommitStatusTracker()
+	}
+	if !cmd.Flag("push-to-git").Changed && promptForAll {
+		io.PushToGit = ui.SelectOptionPushToGit()
+	}
+	if io.Prefix == "" && promptForAll {
+		io.Prefix = ui.EnterPrefix()
+	}
+	outputPathOverridden := cmd.Flag("output").Changed
+	if !outputPathOverridden {
+		// Override the default path to be ./{gitops repo name}
+		repoName, err := repoFromURL(io.GitOpsRepoURL)
+		if err != nil {
+			repoName = "gitops"
+		}
+		io.OutputPath = "./" + repoName
+	}
+	io.OutputPath = ui.VerifyOutputPath(io.OutputPath, io.Overwrite, outputPathOverridden, promptForAll)
 	io.Overwrite = true
 	return nil
+}
+
+func repoFromURL(raw string) (string, error) {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return "", err
+	}
+	parts := strings.Split(u.Path, "/")
+	return strings.TrimSuffix(parts[len(parts)-1], ".git"), nil
 }
 
 func setAccessToken(io *BootstrapParameters) error {
@@ -353,7 +409,7 @@ func NewCmdBootstrap(name, fullName string) *cobra.Command {
 	}
 	bootstrapCmd.Flags().StringVar(&o.GitOpsRepoURL, "gitops-repo-url", "", "Provide the URL for your GitOps repository e.g. https://github.com/organisation/repository.git")
 	bootstrapCmd.Flags().StringVar(&o.GitOpsWebhookSecret, "gitops-webhook-secret", "", "Provide a secret that we can use to authenticate incoming hooks from your Git hosting service for the GitOps repository. (if not provided, it will be auto-generated)")
-	bootstrapCmd.Flags().StringVar(&o.OutputPath, "output", ".", "Path to write GitOps resources")
+	bootstrapCmd.Flags().StringVar(&o.OutputPath, "output", "./gitops", "Path to write GitOps resources")
 	bootstrapCmd.Flags().StringVarP(&o.Prefix, "prefix", "p", "", "Add a prefix to the environment names(Dev, stage,prod,cicd etc.) to distinguish and identify individual environments")
 	bootstrapCmd.Flags().StringVar(&o.DockerConfigJSONFilename, "dockercfgjson", "~/.docker/config.json", "Filepath to config.json which authenticates the image push to the desired image registry ")
 	bootstrapCmd.Flags().StringVar(&o.ImageRepo, "image-repo", "", "Image repository of the form <registry>/<username>/<repository> or <project>/<app> which is used to push newly built images")
@@ -367,6 +423,7 @@ func NewCmdBootstrap(name, fullName string) *cobra.Command {
 	bootstrapCmd.Flags().StringVar(&o.PrivateRepoDriver, "private-repo-driver", "", "If your Git repositories are on a custom domain, please indicate which driver to use github or gitlab")
 	bootstrapCmd.Flags().BoolVar(&o.CommitStatusTracker, "commit-status-tracker", true, "Enable or disable the commit-status-tracker which reports the success/failure of your pipelineruns to GitHub/GitLab")
 	bootstrapCmd.Flags().BoolVar(&o.PushToGit, "push-to-git", false, "If true, automatically creates and populates the gitops-repo-url with the generated resources")
+	bootstrapCmd.Flags().BoolVar(&o.Interactive, "interactive", false, "If true, enable prompting for most options if not already specified on the command line")
 	return bootstrapCmd
 }
 

--- a/pkg/cmd/bootstrap_test.go
+++ b/pkg/cmd/bootstrap_test.go
@@ -223,7 +223,6 @@ func TestValidateMandatoryFlags(t *testing.T) {
 	}{
 		{"missing gitops-repo-url", "", "https://github.com/example/repo.git", "registry/username/repo", false, "", `required flag(s) "gitops-repo-url" not set`},
 		{"missing service-repo-url", "https://github.com/example/repo.git", "", "registry/username/repo", false, "", `required flag(s) "service-repo-url" not set`},
-		{"missing image-repo", "https://github.com/example/repo.git", "https://github.com/example/repo.git", "", false, "", `required flag(s) "image-repo" not set`},
 	}
 
 	for _, tt := range optionTests {
@@ -554,18 +553,18 @@ func TestMissingFlags(t *testing.T) {
 	}{
 		{
 			"Required flags are present",
-			map[string]string{"gitops-repo-url": "value-1", "service-repo-url": "value-2", "image-repo": "value-3"},
+			map[string]string{"gitops-repo-url": "value-1", "service-repo-url": "value-2"},
 			nil,
 		},
 		{
 			"A required flag is absent",
-			map[string]string{"gitops-repo-url": "value-1", "service-repo-url": "value-2", "image-repo": ""},
-			missingFlagErr([]string{`"image-repo"`}),
+			map[string]string{"gitops-repo-url": "value-1", "service-repo-url": ""},
+			missingFlagErr([]string{`"service-repo-url"`}),
 		},
 		{
 			"Multiple required flags are absent",
-			map[string]string{"gitops-repo-url": "value-1", "service-repo-url": "", "image-repo": ""},
-			missingFlagErr([]string{`"service-repo-url"`, `"image-repo"`}),
+			map[string]string{"gitops-repo-url": "", "service-repo-url": ""},
+			missingFlagErr([]string{`"service-repo-url"`, `"gitops-repo-url"`}),
 		},
 	}
 	for _, test := range tests {

--- a/pkg/cmd/ui/ui.go
+++ b/pkg/cmd/ui/ui.go
@@ -2,12 +2,11 @@ package ui
 
 import (
 	"fmt"
+	"github.com/redhat-developer/kam/pkg/pipelines/ioutils"
+	"gopkg.in/AlecAivazis/survey.v1"
 	"net/url"
 	"path/filepath"
 
-	"gopkg.in/AlecAivazis/survey.v1"
-
-	"github.com/redhat-developer/kam/pkg/pipelines/ioutils"
 	"k8s.io/apimachinery/pkg/types"
 )
 
@@ -61,7 +60,7 @@ func EnterImageRepoInternalRegistry() string {
 func EnterDockercfg() string {
 	var dockerCfg string
 	prompt := &survey.Input{
-		Message: "Path to config.json which authenticates image pushes to the desired image registry",
+		Message: "Provide the path to config.json which authenticates image pushes to the desired image registry",
 		Help:    "The secret present in the file path generates a secure secret that authenticates the push of the image built when the app-ci pipeline is run. The image along with the necessary labels will be present on the upstream image registry of choice.",
 		Default: "~/.docker/config.json",
 	}
@@ -85,24 +84,29 @@ func EnterImageRepoExternalRepository() string {
 	return imageRepoExt
 }
 
-// EnterOutputPath allows the user to specify the path where the gitops configuration must reside locally in a UI prompt.
-func EnterOutputPath() string {
-	var outputPath string
+// VerifyOutputPath allows the user to specify the path where the gitops configuration must reside locally in a UI prompt.
+func VerifyOutputPath(originalPath string, overwrite, outputPathOverridden, promptForPath bool) string {
+	var outputPath = originalPath
 	prompt := &survey.Input{
 		Message: "Provide a path to write GitOps resources?",
 		Help:    "This is the path where the GitOps repository configuration is stored locally before you push it to the repository GitopsRepoURL",
-		Default: ".",
+		Default: originalPath,
 	}
-
-	err := survey.AskOne(prompt, &outputPath, nil)
-	exists, filePathError := ioutils.IsExisting(ioutils.NewFilesystem(), filepath.Join(outputPath, "pipelines.yaml"))
-	if exists {
-		SelectOptionOverwrite(outputPath)
+	if !outputPathOverridden && promptForPath {
+		handleError(survey.AskOne(prompt, &outputPath, nil))
 	}
-	if !exists {
-		err = filePathError
+	for true {
+		exists, err := ioutils.IsExisting(ioutils.NewFilesystem(), filepath.Join(outputPath, "pipelines.yaml"))
+		handleError(err)
+		if !exists || overwrite {
+			break
+		}
+		doOverwrite := SelectOptionOverwrite(outputPath)
+		if doOverwrite {
+			break
+		}
+		handleError(survey.AskOne(prompt, &outputPath, nil))
 	}
-	handleError(err)
 	return outputPath
 }
 
@@ -216,16 +220,16 @@ func UseInternalRegistry() bool {
 }
 
 // SelectOptionOverwrite allows users the option to overwrite the current gitops configuration locally through the UI prompt.
-func SelectOptionOverwrite(path string) string {
+func SelectOptionOverwrite(currentPath string) bool {
 	var overwrite string
 	prompt := &survey.Select{
 		Message: "Do you want to overwrite your output path?",
+		Help:    "Overwrite: " + currentPath,
 		Options: []string{"yes", "no"},
 		Default: "no",
 	}
-	err := survey.AskOne(prompt, &overwrite, makeOverWriteValidator(path))
-	handleError(err)
-	return overwrite
+	handleError(survey.AskOne(prompt, &overwrite, nil))
+	return overwrite == "yes"
 }
 
 // SetupCommitStatusTracker allows users the option to select if they
@@ -268,6 +272,19 @@ func SelectOptionPushToGit() bool {
 	err := survey.AskOne(prompt, &optionPushToGit, survey.Required)
 	handleError(err)
 	return optionPushToGit == "yes"
+}
+
+// UseDefaultValues allows users to use default values so that they will be prompted with fewer questions in interactive mode
+func UseDefaultValues() bool {
+	var useDefaults string
+	prompt := &survey.Select{
+		Message: "Do you want to accept all default values and be prompted only for the minimum required options?",
+		Help:    "Select yes to accept default values or select no to be prompted for all options that haven't already been specified on the command line",
+		Options: []string{"yes", "no"},
+		Default: "yes",
+	}
+	handleError(survey.AskOne(prompt, &useDefaults, nil))
+	return useDefaults == "yes"
 }
 
 // UseKeyringRingSvc , allows users an option between the Internal image registry and the external image registry through the UI prompt.

--- a/pkg/cmd/ui/validate.go
+++ b/pkg/cmd/ui/validate.go
@@ -5,12 +5,10 @@ import (
 	"fmt"
 	"net/url"
 	"os"
-	"path/filepath"
 	"strings"
 
 	"github.com/redhat-developer/kam/pkg/cmd/utility"
 	"github.com/redhat-developer/kam/pkg/pipelines/git"
-	"github.com/redhat-developer/kam/pkg/pipelines/ioutils"
 	"github.com/redhat-developer/kam/pkg/pipelines/namespaces"
 	"gopkg.in/AlecAivazis/survey.v1"
 	"gopkg.in/AlecAivazis/survey.v1/terminal"
@@ -30,12 +28,6 @@ func makePrefixValidator() survey.Validator {
 func makeSecretValidator() survey.Validator {
 	return func(input interface{}) error {
 		return validateSecretLength(input)
-	}
-}
-
-func makeOverWriteValidator(path string) survey.Validator {
-	return func(input interface{}) error {
-		return validateOverwriteOption(input, path)
 	}
 }
 
@@ -91,21 +83,6 @@ func validateSecretLength(input interface{}) error {
 		return nil
 	}
 	return nil
-}
-
-// validateOverwriteOption(  validates the URL
-func validateOverwriteOption(input interface{}, path string) error {
-	if s, ok := input.(string); ok {
-		if s == "no" {
-			exists, _ := ioutils.IsExisting(ioutils.NewFilesystem(), filepath.Join(path, "pipelines.yaml"))
-			if exists {
-				EnterOutputPath()
-			}
-		}
-		return nil
-	}
-	return nil
-
 }
 
 // ValidateAccessToken validates if the access token is correct for a particular service repo
@@ -165,11 +142,11 @@ func checkSecretLength(secret string) bool {
 
 // handleError handles UI-related errors, in particular useful to gracefully handle ctrl-c interrupts gracefully
 func handleError(err error) {
-	if err != nil {
-		if err == terminal.InterruptErr {
-			os.Exit(1)
-		} else {
-			klog.V(4).Infof("Encountered an error processing prompt: %v", err)
-		}
+	if err == nil {
+		return
 	}
+	if err == terminal.InterruptErr {
+		os.Exit(1)
+	}
+	klog.V(4).Infof("Encountered an error processing prompt: %v", err)
 }


### PR DESCRIPTION
Signed-off-by: Keith Chong <kykchong@redhat.com>

**What type of PR is this?**
This is for the smart defaulting of the output folder for `kam bootstrap`.  The user will not be prompted to provide an output folder if the default current folder is used or if the `--output string` is used.  This also includes a bug fix for https://github.com/redhat-developer/kam/issues/147 , since testing of the feature uncovered the bug.

/kind bug - Fixes 147
/kind enhancement - See GitOps story 563

**What does this PR do / why we need it**:
See
GitOps story 563
https://github.com/redhat-developer/kam/issues/147

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes https://github.com/redhat-developer/kam/issues/147

**How to test changes / Special notes to the reviewer**:
Run `kam bootstrap` and see if you get prompted for the output folder.  Check that the resources are written to the current folder.
