### PR TITLE
Inconsistent case in Yes/No (yes/no) type of options in bootstrap cmd

### DIFF
--- a/pkg/cmd/ui/ui.go
+++ b/pkg/cmd/ui/ui.go
@@ -276,10 +276,10 @@ func UseKeyringRingSvc() bool {
 	prompt := &survey.Select{
 		Message: "Do you wish to securely store the git-host-access-token in the keyring on your local machine?",
 		Help:    "The token will be stored securely in the keyring of your local mahine. It will be reused by kam commands(bootstrap/webhoook), further iteration of these commands will not prompt for the access-token",
-		Options: []string{"Yes", "No"},
+		Options: []string{"yes", "no"},
 	}
 
 	err := survey.AskOne(prompt, &optionImageRegistry, survey.Required)
 	handleError(err)
-	return optionImageRegistry == "Yes"
+	return optionImageRegistry == "yes"
 }


### PR DESCRIPTION
Signed-off-by: Keith Chong <kykchong@redhat.com>

**What type of PR is this?**

/kind bug

See https://github.com/redhat-developer/kam/issues/151

**What does this PR do / why we need it**:

Fix case consistency: yes/no from Yes/No.  Most prompts currently are lower case

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes https://github.com/redhat-developer/kam/issues/151
