### PR TITLE
Smart default for bootstrap options except for epic point 5; Fix 147

### DIFF
--- a/docs/commands/kam_bootstrap.md
+++ b/docs/commands/kam_bootstrap.md
@@ -27,7 +27,8 @@ kam bootstrap [flags]
       --gitops-webhook-secret string    Provide a secret that we can use to authenticate incoming hooks from your Git hosting service for the GitOps repository. (if not provided, it will be auto-generated)
   -h, --help                            help for bootstrap
       --image-repo string               Image repository of the form <registry>/<username>/<repository> or <project>/<app> which is used to push newly built images
-      --output string                   Path to write GitOps resources (default ".")
+      --interactive                     If true, enable prompting for most options if not already specified on the command line
+      --output string                   Path to write GitOps resources (default "./gitops")
       --overwrite                       Overwrites previously existing GitOps configuration (if any) on the local filesystem
   -p, --prefix string                   Add a prefix to the environment names(Dev, stage,prod,cicd etc.) to distinguish and identify individual environments
       --private-repo-driver string      If your Git repositories are on a custom domain, please indicate which driver to use github or gitlab

--- a/pkg/cmd/bootstrap_test.go
+++ b/pkg/cmd/bootstrap_test.go
@@ -223,7 +223,6 @@ func TestValidateMandatoryFlags(t *testing.T) {
 	}{
 		{"missing gitops-repo-url", "", "https://github.com/example/repo.git", "registry/username/repo", false, "", `required flag(s) "gitops-repo-url" not set`},
 		{"missing service-repo-url", "https://github.com/example/repo.git", "", "registry/username/repo", false, "", `required flag(s) "service-repo-url" not set`},
-		{"missing image-repo", "https://github.com/example/repo.git", "https://github.com/example/repo.git", "", false, "", `required flag(s) "image-repo" not set`},
 	}
 
 	for _, tt := range optionTests {
@@ -554,18 +553,18 @@ func TestMissingFlags(t *testing.T) {
 	}{
 		{
 			"Required flags are present",
-			map[string]string{"gitops-repo-url": "value-1", "service-repo-url": "value-2", "image-repo": "value-3"},
+			map[string]string{"gitops-repo-url": "value-1", "service-repo-url": "value-2"},
 			nil,
 		},
 		{
 			"A required flag is absent",
-			map[string]string{"gitops-repo-url": "value-1", "service-repo-url": "value-2", "image-repo": ""},
-			missingFlagErr([]string{`"image-repo"`}),
+			map[string]string{"gitops-repo-url": "value-1", "service-repo-url": ""},
+			missingFlagErr([]string{`"service-repo-url"`}),
 		},
 		{
 			"Multiple required flags are absent",
-			map[string]string{"gitops-repo-url": "value-1", "service-repo-url": "", "image-repo": ""},
-			missingFlagErr([]string{`"service-repo-url"`, `"image-repo"`}),
+			map[string]string{"gitops-repo-url": "", "service-repo-url": ""},
+			missingFlagErr([]string{`"service-repo-url"`, `"gitops-repo-url"`}),
 		},
 	}
 	for _, test := range tests {

--- a/pkg/cmd/ui/validate.go
+++ b/pkg/cmd/ui/validate.go
@@ -5,12 +5,10 @@ import (
 	"fmt"
 	"net/url"
 	"os"
-	"path/filepath"
 	"strings"
 
 	"github.com/redhat-developer/kam/pkg/cmd/utility"
 	"github.com/redhat-developer/kam/pkg/pipelines/git"
-	"github.com/redhat-developer/kam/pkg/pipelines/ioutils"
 	"github.com/redhat-developer/kam/pkg/pipelines/namespaces"
 	"gopkg.in/AlecAivazis/survey.v1"
 	"gopkg.in/AlecAivazis/survey.v1/terminal"
@@ -30,12 +28,6 @@ func makePrefixValidator() survey.Validator {
 func makeSecretValidator() survey.Validator {
 	return func(input interface{}) error {
 		return validateSecretLength(input)
-	}
-}
-
-func makeOverWriteValidator(path string) survey.Validator {
-	return func(input interface{}) error {
-		return validateOverwriteOption(input, path)
 	}
 }
 
@@ -91,21 +83,6 @@ func validateSecretLength(input interface{}) error {
 		return nil
 	}
 	return nil
-}
-
-// validateOverwriteOption(  validates the URL
-func validateOverwriteOption(input interface{}, path string) error {
-	if s, ok := input.(string); ok {
-		if s == "no" {
-			exists, _ := ioutils.IsExisting(ioutils.NewFilesystem(), filepath.Join(path, "pipelines.yaml"))
-			if exists {
-				EnterOutputPath()
-			}
-		}
-		return nil
-	}
-	return nil
-
 }
 
 // ValidateAccessToken validates if the access token is correct for a particular service repo
@@ -165,11 +142,11 @@ func checkSecretLength(secret string) bool {
 
 // handleError handles UI-related errors, in particular useful to gracefully handle ctrl-c interrupts gracefully
 func handleError(err error) {
-	if err != nil {
-		if err == terminal.InterruptErr {
-			os.Exit(1)
-		} else {
-			klog.V(4).Infof("Encountered an error processing prompt: %v", err)
-		}
+	if err == nil {
+		return
 	}
+	if err == terminal.InterruptErr {
+		os.Exit(1)
+	}
+	klog.V(4).Infof("Encountered an error processing prompt: %v", err)
 }


### PR DESCRIPTION
Signed-off-by: Keith Chong <kykchong@redhat.com>

Have to create another PR. I had an issue with rebase with the original PR: https://github.com/redhat-developer/kam/pull/148.
It's easier just to create a new PR and close the other one.

**What type of PR is this?**
Use this one instead, but see comments from the original PR.
This is for the smart defaulting for kam bootstrap. This also includes a bug fix for #147 , since testing of the feature uncovered the bug.

/kind bug - Fixes 147
/kind enhancement - See GitOps story 563.  Fixes points 1 to 4.

**What does this PR do / why we need it**:
See
GitOps story 563 points 1-4
#147

**Have you updated the necessary documentation?**
(Not yet)

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:
Fixes #147
and GitOps story 563 points 1-4

**How to test changes / Special notes to the reviewer**:
Run kam bootstrap and see if you get prompted for the output folder. Check that the resources are written to the current folder.

