### PR TITLE
Switch to the new TriggerTemplate param naming.

### DIFF
--- a/pkg/pipelines/triggers/pipelinerun.go
+++ b/pkg/pipelines/triggers/pipelinerun.go
@@ -20,7 +20,7 @@ func createDevCDPipelineRun(saName string) pipelinev1.PipelineRun {
 		Spec: pipelinev1.PipelineRunSpec{
 			ServiceAccountName: saName,
 			PipelineRef:        createPipelineRef("app-cd-pipeline"),
-			Resources:          createDevResource("$(params." + GitCommitID + ")"),
+			Resources:          createDevResource("$(tt.params." + GitCommitID + ")"),
 		},
 	}
 }
@@ -31,23 +31,23 @@ func createDevCIPipelineRun(saName string) pipelinev1.PipelineRun {
 		ObjectMeta: meta.ObjectMeta(
 			meta.NamespacedName("", "app-ci-pipeline-run-$(uid)"),
 			statusTrackerAnnotations("dev-ci-build-from-pr", "CI build on push event", map[string]string{
-				"tekton.dev/commit-status-source-url": "$(params.gitrepositoryurl)",
-				"tekton.dev/commit-status-source-sha": "$(params." + GitCommitID + ")",
+				"tekton.dev/commit-status-source-url": "$(tt.params.gitrepositoryurl)",
+				"tekton.dev/commit-status-source-sha": "$(tt.params." + GitCommitID + ")",
 			})),
 		Spec: pipelinev1.PipelineRunSpec{
 			ServiceAccountName: saName,
 			PipelineRef:        createPipelineRef("app-ci-pipeline"),
 			Params: []pipelinev1.Param{
-				createPipelineBindingParam("REPO", "$(params.fullname)"),
-				createPipelineBindingParam("GIT_REPO", "$(params.gitrepositoryurl)"),
-				createPipelineBindingParam("TLSVERIFY", "$(params.tlsVerify)"),
-				createPipelineBindingParam("BUILD_EXTRA_ARGS", "$(params.build_extra_args)"),
-				createPipelineBindingParam("IMAGE", "$(params.imageRepo):$(params."+GitRef+")-$(params."+GitCommitID+")"),
-				createPipelineBindingParam("COMMIT_SHA", "$(params."+GitCommitID+")"),
-				createPipelineBindingParam("GIT_REF", "$(params."+GitRef+")"),
-				createPipelineBindingParam("COMMIT_DATE", "$(params."+GitCommitDate+")"),
-				createPipelineBindingParam("COMMIT_AUTHOR", "$(params."+GitCommitAuthor+")"),
-				createPipelineBindingParam("COMMIT_MESSAGE", "$(params."+GitCommitMessage+")"),
+				createPipelineBindingParam("REPO", "$(tt.params.fullname)"),
+				createPipelineBindingParam("GIT_REPO", "$(tt.params.gitrepositoryurl)"),
+				createPipelineBindingParam("TLSVERIFY", "$(tt.params.tlsVerify)"),
+				createPipelineBindingParam("BUILD_EXTRA_ARGS", "$(tt.params.build_extra_args)"),
+				createPipelineBindingParam("IMAGE", "$(tt.params.imageRepo):$(tt.params."+GitRef+")-$(tt.params."+GitCommitID+")"),
+				createPipelineBindingParam("COMMIT_SHA", "$(tt.params."+GitCommitID+")"),
+				createPipelineBindingParam("GIT_REF", "$(tt.params."+GitRef+")"),
+				createPipelineBindingParam("COMMIT_DATE", "$(tt.params."+GitCommitDate+")"),
+				createPipelineBindingParam("COMMIT_AUTHOR", "$(tt.params."+GitCommitAuthor+")"),
+				createPipelineBindingParam("COMMIT_MESSAGE", "$(tt.params."+GitCommitMessage+")"),
 			},
 			Workspaces: []pipelinev1.WorkspaceBinding{
 				{
@@ -100,7 +100,7 @@ func createDevResource(revision string) []pipelinev1.PipelineResourceBinding {
 				Type: "git",
 				Params: []pipelinev1.ResourceParam{
 					createResourceParams("revision", revision),
-					createResourceParams("url", "$(params.gitrepositoryurl)"),
+					createResourceParams("url", "$(tt.params.gitrepositoryurl)"),
 				},
 			},
 		},
@@ -114,8 +114,8 @@ func createResources() []pipelinev1.PipelineResourceBinding {
 			ResourceSpec: &pipelinev1alpha1.PipelineResourceSpec{
 				Type: "git",
 				Params: []pipelinev1.ResourceParam{
-					createResourceParams("revision", "$(params."+GitCommitID+")"),
-					createResourceParams("url", "$(params.gitrepositoryurl)"),
+					createResourceParams("revision", "$(tt.params."+GitCommitID+")"),
+					createResourceParams("url", "$(tt.params.gitrepositoryurl)"),
 				},
 			},
 		},

--- a/pkg/pipelines/triggers/pipelinerun_test.go
+++ b/pkg/pipelines/triggers/pipelinerun_test.go
@@ -24,7 +24,7 @@ func TestCreateDevCDPipelineRun(t *testing.T) {
 		Spec: pipelinev1.PipelineRunSpec{
 			ServiceAccountName: sName,
 			PipelineRef:        createPipelineRef("app-cd-pipeline"),
-			Resources:          createDevResource("$(params.io.openshift.build.commit.id)"),
+			Resources:          createDevResource("$(tt.params.io.openshift.build.commit.id)"),
 		},
 	}
 	template := createDevCDPipelineRun(sName)
@@ -40,8 +40,8 @@ func TestCreateDevCIPipelineRun(t *testing.T) {
 			meta.NamespacedName("", "app-ci-pipeline-run-$(uid)"),
 			func(om *metav1.ObjectMeta) {
 				om.Annotations = map[string]string{
-					"tekton.dev/commit-status-source-sha": "$(params.io.openshift.build.commit.id)",
-					"tekton.dev/commit-status-source-url": "$(params.gitrepositoryurl)",
+					"tekton.dev/commit-status-source-sha": "$(tt.params.io.openshift.build.commit.id)",
+					"tekton.dev/commit-status-source-url": "$(tt.params.gitrepositoryurl)",
 					"tekton.dev/git-status":               "true",
 					"tekton.dev/status-context":           "dev-ci-build-from-pr",
 					"tekton.dev/status-description":       "CI build on push event",
@@ -64,16 +64,16 @@ func TestCreateDevCIPipelineRun(t *testing.T) {
 				},
 			},
 			Params: []pipelinev1.Param{
-				createPipelineBindingParam("REPO", "$(params.fullname)"),
-				createPipelineBindingParam("GIT_REPO", "$(params.gitrepositoryurl)"),
-				createPipelineBindingParam("TLSVERIFY", "$(params.tlsVerify)"),
-				createPipelineBindingParam("BUILD_EXTRA_ARGS", "$(params.build_extra_args)"),
-				createPipelineBindingParam("IMAGE", "$(params.imageRepo):$(params."+GitRef+")-$(params."+GitCommitID+")"),
-				createPipelineBindingParam("COMMIT_SHA", "$(params.io.openshift.build.commit.id)"),
-				createPipelineBindingParam("GIT_REF", "$(params.io.openshift.build.commit.ref)"),
-				createPipelineBindingParam("COMMIT_DATE", "$(params.io.openshift.build.commit.date)"),
-				createPipelineBindingParam("COMMIT_AUTHOR", "$(params.io.openshift.build.commit.author)"),
-				createPipelineBindingParam("COMMIT_MESSAGE", "$(params.io.openshift.build.commit.message)"),
+				createPipelineBindingParam("REPO", "$(tt.params.fullname)"),
+				createPipelineBindingParam("GIT_REPO", "$(tt.params.gitrepositoryurl)"),
+				createPipelineBindingParam("TLSVERIFY", "$(tt.params.tlsVerify)"),
+				createPipelineBindingParam("BUILD_EXTRA_ARGS", "$(tt.params.build_extra_args)"),
+				createPipelineBindingParam("IMAGE", "$(tt.params.imageRepo):$(tt.params."+GitRef+")-$(tt.params."+GitCommitID+")"),
+				createPipelineBindingParam("COMMIT_SHA", "$(tt.params.io.openshift.build.commit.id)"),
+				createPipelineBindingParam("GIT_REF", "$(tt.params.io.openshift.build.commit.ref)"),
+				createPipelineBindingParam("COMMIT_DATE", "$(tt.params.io.openshift.build.commit.date)"),
+				createPipelineBindingParam("COMMIT_AUTHOR", "$(tt.params.io.openshift.build.commit.author)"),
+				createPipelineBindingParam("COMMIT_MESSAGE", "$(tt.params.io.openshift.build.commit.message)"),
 			},
 		},
 	}
@@ -125,7 +125,7 @@ func TestCreateDevResource(t *testing.T) {
 				Type: "git",
 				Params: []pipelinev1.ResourceParam{
 					createResourceParams("revision", "test"),
-					createResourceParams("url", "$(params.gitrepositoryurl)"),
+					createResourceParams("url", "$(tt.params.gitrepositoryurl)"),
 				},
 			},
 		},


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What does this PR do / why we need it**:

There was a change to TriggerTemplate parameter naming, which involved adding a 'tt.' prefix.

This ensures that the TriggerTemplates that are generated will have the correct prefix.

See the breaking change here https://github.com/tektoncd/triggers/releases/tag/v0.7.0

(OpenShift pipelines has been updated to use v0.8.x)

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:
