### PR TITLE
Improve support for GitLab project repos.

### DIFF
--- a/pkg/pipelines/git/repository.go
+++ b/pkg/pipelines/git/repository.go
@@ -96,14 +96,14 @@ func GetRepoName(u *url.URL) (string, error) {
 			components = append(components, s)
 		}
 	}
-	if len(components) != 2 {
+	if len(components) == 1 {
 		return "", errors.New("failed to get Git repo: " + u.Path)
 	}
-	components[1] = strings.TrimSuffix(components[1], ".git")
+	components[len(components)-1] = strings.TrimSuffix(components[len(components)-1], ".git")
 	for _, s := range components {
 		if strings.Contains(s, ".") {
 			return "", errors.New("failed to get Git repo: " + u.Path)
 		}
 	}
-	return components[0] + "/" + components[1], nil
+	return strings.Join(components, "/"), nil
 }

--- a/pkg/pipelines/git/repository_test.go
+++ b/pkg/pipelines/git/repository_test.go
@@ -1,6 +1,7 @@
 package git
 
 import (
+	"net/url"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -149,5 +150,32 @@ func TestCreateWebHook(t *testing.T) {
 
 	if created != "1" {
 		t.Errorf("failed to create webhook, got %q, want %q", created, "1")
+	}
+}
+
+func TestGetRepoName(t *testing.T) {
+	urlTests := []struct {
+		url      string
+		wantRepo string
+	}{
+		{"https://github.com/example/gitops.git?ref=main", "example/gitops"},
+		{"https://github.com/example/testing.git", "example/testing"},
+		{"https://gitlab.com/project/example/testing.git", "project/example/testing"},
+	}
+
+	for _, tt := range urlTests {
+		t.Run(tt.url, func(t *testing.T) {
+			u, err := url.Parse(tt.url)
+			if err != nil {
+				t.Fatal(err)
+			}
+			repo, err := GetRepoName(u)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if repo != tt.wantRepo {
+				t.Errorf("repo got %s, want %s", repo, tt.wantRepo)
+			}
+		})
 	}
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What does this PR do / why we need it**:

This fixes the behaviour when parsing GitLab's "project" repos, where a repo
can be inside a project.

The change is to assume that everything after the host is part of the repo,
thus https://gitlab.com/org/project/repo.git would be from repo
org/project/repo.

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes: #166 

**How to test changes / Special notes to the reviewer**:

Create a group, create a new repo in the group (cloning from an existing one that you're using).

Use the full repo URL in the service repo url e.g. https://gitlab.com/group/subgroup/repo.git

**There's a caveat around this, it doesn't currently support automatically creating a new repo within a group**

This is a bit tougher to fix, because we currently handle GitHub's weird behaviour :-(