### PR TITLE
Address issue with multiple namespace files being created.

### DIFF
--- a/pkg/pipelines/bootstrap_test.go
+++ b/pkg/pipelines/bootstrap_test.go
@@ -126,7 +126,7 @@ func TestBootstrapManifest(t *testing.T) {
 
 	wantResources := []string{
 		"01-namespaces/cicd-environment.yaml",
-		"01-namespaces/image.yaml",
+		"01-namespaces/image-environment.yaml",
 		"02-rolebindings/commit-status-tracker-role.yaml",
 		"02-rolebindings/commit-status-tracker-rolebinding.yaml",
 		"02-rolebindings/commit-status-tracker-service-account.yaml",

--- a/pkg/pipelines/imagerepo/imagerepo.go
+++ b/pkg/pipelines/imagerepo/imagerepo.go
@@ -70,7 +70,7 @@ func CreateInternalRegistryResources(cfg *config.PipelinesConfig, sa *corev1.Ser
 	resources := res.Resources{}
 	filenames := []string{}
 
-	filename := filepath.Join("01-namespaces", fmt.Sprintf("%s.yaml", namespace))
+	filename := filepath.Join("01-namespaces", fmt.Sprintf("%s-environment.yaml", namespace))
 	namespacePath := filepath.Join(config.PathForPipelines(cfg), "base", filename)
 	resources[namespacePath] = namespaces.Create(namespace, gitOpsRepoURL)
 	filenames = append(filenames, filename)


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What does this PR do / why we need it**:
When the internal registry is used, we generate more than one namespace file.

This causes issues in ArgoCD because there are duplicates of the same K8s object.

This ensures that the files have the same name, which means that whichever way they are created, they exist in the directory.

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:
