### PR TITLE
Fix bootrap command generating duplicate namespace entries in kustomization.yaml

### DIFF
--- a/pkg/cmd/utility/utility.go
+++ b/pkg/cmd/utility/utility.go
@@ -42,6 +42,20 @@ func RemoveEmptyStrings(s []string) []string {
 	return nonempty
 }
 
+// RemoveDuplicates returns a slice with all the duplicate strings removed from the
+// source slice.
+func RemoveDuplicates(s []string) []string {
+	exists := make(map[string]bool)
+	out := []string{}
+	for _, v := range s {
+		if !exists[v] {
+			out = append(out, v)
+			exists[v] = true
+		}
+	}
+	return out
+}
+
 // MaybeCompletePrefix adds a hyphen on the end of the prefix if it doesn't have
 // one to make prefix-generated names look a bit nicer.
 func MaybeCompletePrefix(s string) string {

--- a/pkg/cmd/utility/utility_test.go
+++ b/pkg/cmd/utility/utility_test.go
@@ -40,6 +40,29 @@ func TestAddGitSuffix(t *testing.T) {
 	}
 }
 
+func TestRemoveDuplicates(t *testing.T) {
+	stringsTests := []struct {
+		name   string
+		source []string
+		want   []string
+	}{
+		{"no strings", []string{}, []string{}},
+		{"no duplicates", []string{"test/foo1.bar", "test/foo.bar", "test/foo2.bar", "test1/good"}, []string{"test/foo1.bar", "test/foo.bar", "test/foo2.bar", "test1/good"}},
+		{"1 duplicate", []string{"test/foo.bar", "test/foo.bar", "test1/good"}, []string{"test/foo.bar", "test1/good"}},
+		{"3 of a kind", []string{"test/foo.bar", "test/foo.bar", "test/foo.bar", "test1/good"}, []string{"test/foo.bar", "test1/good"}},
+		{"2 duplicates", []string{"test/foo1.bar", "test/foo1.bar", "test/foo.bar", "test/foo.bar", "test1/good"}, []string{"test/foo1.bar", "test/foo.bar", "test1/good"}},
+	}
+
+	for _, tt := range stringsTests {
+		t.Run(tt.name, func(rt *testing.T) {
+			got := RemoveDuplicates(tt.source)
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				rt.Fatalf("string removal failed:\n%s", diff)
+			}
+		})
+	}
+}
+
 func TestRemoveEmptyStrings(t *testing.T) {
 	stringsTests := []struct {
 		name   string

--- a/pkg/pipelines/bootstrap.go
+++ b/pkg/pipelines/bootstrap.go
@@ -18,6 +18,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
+	"github.com/redhat-developer/kam/pkg/cmd/utility"
 	"github.com/redhat-developer/kam/pkg/pipelines/argocd"
 	"github.com/redhat-developer/kam/pkg/pipelines/config"
 	"github.com/redhat-developer/kam/pkg/pipelines/deployment"
@@ -289,7 +290,7 @@ func bootstrapResources(o *BootstrapOptions, appFs afero.Fs) (res.Resources, err
 	}
 	bootstrapped[pipelinesFile] = m
 
-	k.Resources = append(k.Resources, secretFilename, imageRepoBindingFilename)
+	k.Resources = utility.RemoveDuplicates(append(k.Resources, secretFilename, imageRepoBindingFilename))
 	sort.Strings(k.Resources)
 	bootstrapped[kustomizePath] = k
 

--- a/pkg/pipelines/bootstrap_test.go
+++ b/pkg/pipelines/bootstrap_test.go
@@ -43,7 +43,7 @@ func TestBootstrapManifest(t *testing.T) {
 	params := &BootstrapOptions{
 		Prefix:               "tst-",
 		GitOpsRepoURL:        testGitOpsRepo,
-		ImageRepo:            "image/repo",
+		ImageRepo:            "cicd/repo",
 		GitOpsWebhookSecret:  "123",
 		GitHostAccessToken:   "test-token",
 		ServiceRepoURL:       testSvcRepo,
@@ -126,11 +126,10 @@ func TestBootstrapManifest(t *testing.T) {
 
 	wantResources := []string{
 		"01-namespaces/cicd-environment.yaml",
-		"01-namespaces/image-environment.yaml",
 		"02-rolebindings/commit-status-tracker-role.yaml",
 		"02-rolebindings/commit-status-tracker-rolebinding.yaml",
 		"02-rolebindings/commit-status-tracker-service-account.yaml",
-		"02-rolebindings/internal-registry-image-binding.yaml",
+		"02-rolebindings/internal-registry-cicd-binding.yaml",
 		"02-rolebindings/pipeline-service-account.yaml",
 		"02-rolebindings/pipeline-service-role.yaml",
 		"02-rolebindings/pipeline-service-rolebinding.yaml",


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What does this PR do / why we need it**:
This PR fixes https://issues.redhat.com/browse/GITOPS-674

**Have you updated the necessary documentation?**
* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #?
https://issues.redhat.com/browse/GITOPS-674

**How to test changes / Special notes to the reviewer**:

1. Follow https://github.com/redhat-developer/kam/tree/master/docs/journey/day1 to install GitOps Operator and Sealed Secret.
2. `kam bootstrap` to generate GitOps configuration using `Smart Defaults`.  The key is to use the default internal image registry with namespace `cicd`.
3. Verify that the generated <gitops>/config/cicd/base/kustomization.yanl has NO duplicate entries in particular no duplicate entries for `01-namespaces/cicd-environment.yaml`
4. Proceed to the steps in Day 1 operator to push configuration to GitOps repository and execute `oc apply -f <gitops>/config/argocd`
5. Login to Argo CD UI and verify that all argod apps (in particular cicd-app) are successfully sync'ed.