### PR TITLE
Remove duplicates when adding to the Kustomization representation.

### DIFF
--- a/pkg/pipelines/bootstrap.go
+++ b/pkg/pipelines/bootstrap.go
@@ -278,7 +278,7 @@ func bootstrapResources(o *BootstrapOptions, appFs afero.Fs) (res.Resources, err
 			return nil, fmt.Errorf("failed to get resources for internal image repository: %v", err)
 		}
 		bootstrapped = res.Merge(resources, bootstrapped)
-		k.Resources = append(k.Resources, filenames...)
+		k.AddResources(filenames...)
 	}
 
 	// This is specific to bootstrap, because there's only one service.
@@ -289,8 +289,7 @@ func bootstrapResources(o *BootstrapOptions, appFs afero.Fs) (res.Resources, err
 	}
 	bootstrapped[pipelinesFile] = m
 
-	k.Resources = append(k.Resources, secretFilename, imageRepoBindingFilename)
-	sort.Strings(k.Resources)
+	k.AddResources(secretFilename, imageRepoBindingFilename)
 	bootstrapped[kustomizePath] = k
 
 	bootstrapped = res.Merge(svcFiles, bootstrapped)

--- a/pkg/pipelines/resources/kustomization.go
+++ b/pkg/pipelines/resources/kustomization.go
@@ -1,8 +1,27 @@
 package resources
 
+import "sort"
+
 // Kustomization is a structural representation of the Kustomize file format.
 type Kustomization struct {
 	Resources    []string          `json:"resources,omitempty"`
 	Bases        []string          `json:"bases,omitempty"`
 	CommonLabels map[string]string `json:"commonLabels,omitempty"`
+}
+
+func (k *Kustomization) AddResources(s ...string) {
+	k.Resources = removeDuplicatesAndSort(append(k.Resources, s...))
+}
+
+func removeDuplicatesAndSort(s []string) []string {
+	exists := make(map[string]bool)
+	out := []string{}
+	for _, v := range s {
+		if !exists[v] {
+			out = append(out, v)
+			exists[v] = true
+		}
+	}
+	sort.Strings(out)
+	return out
 }

--- a/pkg/pipelines/resources/kustomization_test.go
+++ b/pkg/pipelines/resources/kustomization_test.go
@@ -1,0 +1,35 @@
+package resources
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func Test_AddResource(t *testing.T) {
+	k := Kustomization{}
+	k.AddResources("testing.yaml", "testing2.yaml")
+
+	if diff := cmp.Diff([]string{"testing.yaml", "testing2.yaml"}, k.Resources); diff != "" {
+		t.Fatalf("failed to add resources:\n%s", diff)
+	}
+}
+
+func Test_AddResource_with_duplicates(t *testing.T) {
+	k := Kustomization{}
+	k.AddResources("testing.yaml", "testing2.yaml")
+	k.AddResources("testing.yaml")
+
+	if diff := cmp.Diff([]string{"testing.yaml", "testing2.yaml"}, k.Resources); diff != "" {
+		t.Fatalf("failed to add resources:\n%s", diff)
+	}
+}
+
+func Test_AddResource_sorts_elements(t *testing.T) {
+	k := Kustomization{}
+	k.AddResources("service.yaml", "deployment.yaml", "namespace.yaml")
+
+	if diff := cmp.Diff([]string{"deployment.yaml", "namespace.yaml", "service.yaml"}, k.Resources); diff != "" {
+		t.Fatalf("failed to sort resources:\n%s", diff)
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**

> /kind cleanup

**What does this PR do / why we need it**:

This adds functionality for adding resources to the Kustomization, which will
filter out duplicate entries and maintain the element in string-sorted order.

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:
