### PR TITLE
Make Argo CD admin in environments managed by kam

### DIFF
--- a/docs/journey/day1/README.md
+++ b/docs/journey/day1/README.md
@@ -236,6 +236,14 @@ The `pipelines` field describes the templates and bindings used for this service
 
 The`webhook.secret` is used to authenticate incoming hooks from Git host.
 
+## Argo CD Permissions
+
+By default, kam provides admin privileges to Argo CD application controller service account. For each environment
+managed by kam, a rolebinding file is generated, that makes Argo CD an admin in that environment. In order to modify it, 
+update the argocd-admin rolebinding file
+
+* `environments/<name>/env/base/argocd-admin.yaml`
+
 ## Bringing the bootstrapped environment up
 
 First of all, let's get started with our Git repository.

--- a/docs/journey/day1/prerequisites/argocd.md
+++ b/docs/journey/day1/prerequisites/argocd.md
@@ -23,13 +23,3 @@ Click on the ArgoCD operator as shown below in the OperatorHub on your OpenShift
 ![screenshot](img/argocd-3.png)
 
 ![screenshot](img/argocd-4.png)
-
-## Add Role Binding
-
-Note: Due to an open [issue](https://github.com/argoproj-labs/argocd-operator/issues/107) the operator may not create enough privileges to manage multiple namespaces.
-
-In order to solve this apply:
-
-```shell
-$ oc adm policy add-cluster-role-to-user cluster-admin system:serviceaccount:argocd:argocd-application-controller
-```

--- a/docs/journey/day1/prerequisites/gitops_operator.md
+++ b/docs/journey/day1/prerequisites/gitops_operator.md
@@ -13,33 +13,3 @@ Follow the installation wizard and deploy the operator with defaults.
 ![screenshot](img/gitops-installation.png)
 
 ![screenshot](img/argocd-instance.png)
-
-## Add Role Binding
-
-The operator may not create enough privileges to manage multiple namespaces. In order to solve this:
-
-1. Provide cluster-admin access to argocd-application-controller service account.
-
-```shell
-$ oc adm policy add-cluster-role-to-user cluster-admin system:serviceaccount:openshift-gitops:argocd-cluster-argocd-application-controller
-```
-
-2. Provide custom privileges to `argocd-application-controller` service account and restrict access to argocd.
-
-Example
-
-```yaml
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: application-controller
-  namespace: <env> 
-subjects:
-- kind: ServiceAccount
-  name: argocd-application-controller
-  apiGroup: ""
-roleRef:
-  kind: Role
-  name: <argocd-role>
-  apiGroup: rbac.authorization.k8s.io
-```

--- a/pkg/cmd/bootstrap.go
+++ b/pkg/cmd/bootstrap.go
@@ -37,7 +37,7 @@ const (
 	gitopsRepoURLFlag     = "gitops-repo-url"
 	serviceRepoURLFlag    = "service-repo-url"
 	imageRepoFlag         = "image-repo"
-	argoCdOperatorName    = "ArgoCD Operator"
+	gitopsOperatorName    = "OpenShift GitOps Operator"
 	pipelinesOperatorName = "OpenShift Pipelines Operator"
 )
 
@@ -311,9 +311,9 @@ func checkBootstrapDependencies(io *BootstrapParameters, client *utility.Client,
 	if err := client.CheckIfArgoCDExists(argocd.ArgoCDNamespace); err != nil {
 		warnIfNotFound(spinner, "Please install OpenShift GitOps Operator from OperatorHub", err)
 		if !apierrors.IsNotFound(err) {
-			return fmt.Errorf("failed to check for ArgoCD Operator: %w", err)
+			return fmt.Errorf("failed to check for OpenShift GitOps Operator: %w", err)
 		}
-		missingDeps = append(missingDeps, argoCdOperatorName)
+		missingDeps = append(missingDeps, gitopsOperatorName)
 	}
 
 	spinner.Start("Checking if OpenShift Pipelines Operator is installed with the default configuration", false)

--- a/pkg/cmd/bootstrap_test.go
+++ b/pkg/cmd/bootstrap_test.go
@@ -289,7 +289,7 @@ Checking if OpenShift Pipelines Operator is installed with the default configura
 	err := checkBootstrapDependencies(
 		&BootstrapParameters{BootstrapOptions: &pipelines.BootstrapOptions{SealedSecretsService: types.NamespacedName{Namespace: secrets.SealedSecretsNS, Name: secrets.SealedSecretsController}}},
 		fakeClient, fakeSpinner)
-	wantErr := fmt.Sprintf("failed to satisfy the required dependencies: %s, %s", argoCdOperatorName, pipelinesOperatorName)
+	wantErr := fmt.Sprintf("failed to satisfy the required dependencies: %s, %s", gitopsOperatorName, pipelinesOperatorName)
 
 	assertError(t, err, wantErr)
 	assertMessage(t, buff.String(), wantMsg)
@@ -415,7 +415,7 @@ Checking if OpenShift Pipelines Operator is installed with the default configura
 		BootstrapOptions: &pipelines.BootstrapOptions{},
 	}
 	err := checkBootstrapDependencies(wizardParams, fakeClient, fakeSpinner)
-	wantErr := fmt.Sprintf("failed to satisfy the required dependencies: %s", argoCdOperatorName)
+	wantErr := fmt.Sprintf("failed to satisfy the required dependencies: %s", gitopsOperatorName)
 
 	assertError(t, err, wantErr)
 	assertMessage(t, buff.String(), wantMsg)

--- a/pkg/pipelines/argocd/argocd.go
+++ b/pkg/pipelines/argocd/argocd.go
@@ -8,6 +8,8 @@ import (
 	// version of k8s in common with kam.
 
 	argoappv1 "github.com/redhat-developer/kam/pkg/pipelines/argocd/v1alpha1"
+	"github.com/redhat-developer/kam/pkg/pipelines/roles"
+	rbacv1 "k8s.io/api/rbac/v1"
 
 	"github.com/redhat-developer/kam/pkg/pipelines/config"
 	"github.com/redhat-developer/kam/pkg/pipelines/meta"
@@ -63,8 +65,10 @@ const (
 	// ArgoCDNamespace is the default namespace for ArgoCD installations.
 	ArgoCDNamespace = "openshift-gitops"
 
-	defaultServer  = "https://kubernetes.default.svc"
-	defaultProject = "default"
+	defaultServer          = "https://kubernetes.default.svc"
+	defaultProject         = "default"
+	argoCDSAName           = "argocd-cluster-argocd-application-controller"
+	argocdAdminBindingName = "argocd-admin"
 )
 
 // Build creates and returns a set of resources to be used for the ArgoCD
@@ -210,4 +214,10 @@ func clusterForEnv(env *config.Environment) string {
 		return env.Cluster
 	}
 	return defaultServer
+}
+
+// MakeApplicationControllerAdmin returns a rolebinding with argocd application controller as an admin in the given namespace
+func MakeApplicationControllerAdmin(ns string) *rbacv1.RoleBinding {
+	argocdSA := roles.CreateServiceAccount(meta.NamespacedName(ArgoCDNamespace, argoCDSAName))
+	return roles.CreateRoleBinding(meta.NamespacedName(ns, argocdAdminBindingName), argocdSA, "ClusterRole", "admin")
 }

--- a/pkg/pipelines/bootstrap.go
+++ b/pkg/pipelines/bootstrap.go
@@ -47,6 +47,8 @@ const (
 	rolesPath             = "02-rolebindings/pipeline-service-role.yaml"
 	rolebindingsPath      = "02-rolebindings/pipeline-service-rolebinding.yaml"
 	serviceAccountPath    = "02-rolebindings/pipeline-service-account.yaml"
+	sealedSecretRolePath  = "02-rolebindings/sealed-secrets-aggregate-to-admin.yaml"
+	argocdAdminRolePath   = "02-rolebindings/argocd-admin.yaml"
 	secretsPath           = "03-secrets/gitops-webhook-secret.yaml"     //nolint:gosec
 	authTokenPath         = "03-secrets/git-host-access-token.yaml"     // nolint:gosec
 	basicAuthTokenPath    = "03-secrets/git-host-basic-auth-token.yaml" // nolint:gosec
@@ -69,6 +71,8 @@ const (
 	bootstrapImage    = "nginxinc/nginx-unprivileged:latest"
 	appCITemplateName = "app-ci-template"
 	version           = 1
+
+	sealedsecretsAggregate = "sealed-secrets-aggregate-to-admin"
 )
 
 // BootstrapOptions is a struct that provides the optional flags
@@ -532,6 +536,12 @@ func createCICDResources(fs afero.Fs, repo scm.Repository, pipelineConfig *confi
 		log.Success("Pipelines tracker has been configured")
 	}
 
+	// aggregate sealed secrets cluster role to OpenShift admin cluster role
+	// we can remove this file when it's fixed in upstream Sealed Secrets operator
+	outputs[sealedSecretRolePath] = aggregateSealedSecretsToAdmin()
+
+	outputs[argocdAdminRolePath] = argocd.MakeApplicationControllerAdmin(cicdNamespace)
+
 	outputs[rolebindingsPath] = roles.CreateClusterRoleBinding(meta.NamespacedName("", roleBindingName), sa, "ClusterRole", roles.ClusterRoleName)
 	script, err := dryrun.MakeScript("kubectl", cicdNamespace)
 	if err != nil {
@@ -594,6 +604,22 @@ func getResourceFiles(r res.Resources) []string {
 	}
 	sort.Strings(files)
 	return files
+}
+
+func aggregateSealedSecretsToAdmin() *v1rbac.ClusterRole {
+	policyRule := []v1rbac.PolicyRule{
+		{
+			APIGroups: []string{"bitnami.com"},
+			Resources: []string{"sealedsecrets"},
+			Verbs:     []string{"*"},
+		},
+	}
+	aggregateToAdminLabel := func(cl *v1rbac.ClusterRole) {
+		cl.SetLabels(map[string]string{
+			"rbac.authorization.k8s.io/aggregate-to-admin": "true",
+		})
+	}
+	return roles.CreateClusterRole(meta.NamespacedName("", sealedsecretsAggregate), policyRule, aggregateToAdminLabel)
 }
 
 func generateSecrets(outputs res.Resources, sa *corev1.ServiceAccount, ns string, o *BootstrapOptions) error {

--- a/pkg/pipelines/bootstrap_test.go
+++ b/pkg/pipelines/bootstrap_test.go
@@ -127,6 +127,7 @@ func TestBootstrapManifest(t *testing.T) {
 	wantResources := []string{
 		"01-namespaces/cicd-environment.yaml",
 		"01-namespaces/image-environment.yaml",
+		"02-rolebindings/argocd-admin.yaml",
 		"02-rolebindings/commit-status-tracker-role.yaml",
 		"02-rolebindings/commit-status-tracker-rolebinding.yaml",
 		"02-rolebindings/commit-status-tracker-service-account.yaml",
@@ -134,6 +135,7 @@ func TestBootstrapManifest(t *testing.T) {
 		"02-rolebindings/pipeline-service-account.yaml",
 		"02-rolebindings/pipeline-service-role.yaml",
 		"02-rolebindings/pipeline-service-rolebinding.yaml",
+		"02-rolebindings/sealed-secrets-aggregate-to-admin.yaml",
 		"03-secrets/git-host-access-token.yaml",
 		"03-secrets/git-host-basic-auth-token.yaml",
 		"03-secrets/gitops-webhook-secret.yaml",

--- a/pkg/pipelines/environments/environments.go
+++ b/pkg/pipelines/environments/environments.go
@@ -8,6 +8,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/redhat-developer/kam/pkg/pipelines/argocd"
 	"github.com/redhat-developer/kam/pkg/pipelines/config"
 	"github.com/redhat-developer/kam/pkg/pipelines/meta"
 	"github.com/redhat-developer/kam/pkg/pipelines/namespaces"
@@ -108,6 +109,12 @@ func (b *envBuilder) Environment(env *config.Environment) error {
 	if _, ok := b.files[envBindingPath]; ok {
 		envFiles[envBindingPath] = b.files[envBindingPath]
 	}
+
+	argocdAdminPath := filepath.Join(basePath, "argocd-admin.yaml")
+	if _, ok := b.files[argocdAdminPath]; !ok {
+		envFiles[argocdAdminPath] = argocd.MakeApplicationControllerAdmin(env.Name)
+	}
+
 	for k := range envFiles {
 		kustomizedFilenames[filepath.Base(k)] = true
 	}

--- a/pkg/pipelines/environments/environments_test.go
+++ b/pkg/pipelines/environments/environments_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/redhat-developer/kam/pkg/pipelines/argocd"
 	"github.com/redhat-developer/kam/pkg/pipelines/config"
 	"github.com/redhat-developer/kam/pkg/pipelines/ioutils"
 	"github.com/redhat-developer/kam/pkg/pipelines/namespaces"
@@ -30,6 +31,7 @@ func TestBuildEnvironmentFilesWithAppsToEnvironment(t *testing.T) {
 				"../services/service-metrics",
 			},
 		},
+		"environments/test-dev/env/base/argocd-admin.yaml": argocd.MakeApplicationControllerAdmin("test-dev"),
 		"environments/test-dev/apps/my-app-1/kustomization.yaml": &res.Kustomization{
 			Bases: []string{"overlays"},
 			CommonLabels: map[string]string{
@@ -38,7 +40,7 @@ func TestBuildEnvironmentFilesWithAppsToEnvironment(t *testing.T) {
 		"environments/test-dev/apps/my-app-1/overlays/kustomization.yaml":                          &res.Kustomization{Bases: []string{"../base"}},
 		"environments/test-dev/env/base/test-dev-environment.yaml":                                 namespaces.Create("test-dev", testGitOpsRepoURL),
 		"environments/test-dev/env/base/test-dev-rolebinding.yaml":                                 createRoleBinding(m.Environments[0], "cicd", "pipelines"),
-		"environments/test-dev/env/base/kustomization.yaml":                                        &res.Kustomization{Resources: []string{"test-dev-environment.yaml", "test-dev-rolebinding.yaml"}},
+		"environments/test-dev/env/base/kustomization.yaml":                                        &res.Kustomization{Resources: []string{"argocd-admin.yaml", "test-dev-environment.yaml", "test-dev-rolebinding.yaml"}},
 		"environments/test-dev/env/overlays/kustomization.yaml":                                    &res.Kustomization{Bases: []string{"../base"}},
 		"environments/test-dev/apps/my-app-1/services/service-http/kustomization.yaml":             &res.Kustomization{Bases: []string{"overlays"}},
 		"environments/test-dev/apps/my-app-1/services/service-http/base/kustomization.yaml":        &res.Kustomization{Bases: []string{"./config"}},
@@ -68,6 +70,7 @@ func TestBuildEnvironmentFilesWithEnvironmentsToApps(t *testing.T) {
 				"../services/service-metrics",
 			},
 		},
+		"environments/test-dev/env/base/argocd-admin.yaml": argocd.MakeApplicationControllerAdmin("test-dev"),
 		"environments/test-dev/apps/my-app-1/kustomization.yaml": &res.Kustomization{
 			Bases: []string{"overlays"},
 			CommonLabels: map[string]string{
@@ -78,7 +81,7 @@ func TestBuildEnvironmentFilesWithEnvironmentsToApps(t *testing.T) {
 		"environments/test-dev/env/base/test-dev-environment.yaml":        namespaces.Create("test-dev", testGitOpsRepoURL),
 		"environments/test-dev/env/base/test-dev-rolebinding.yaml":        createRoleBinding(m.Environments[0], "cicd", "pipelines"),
 		"environments/test-dev/env/base/kustomization.yaml": &res.Kustomization{
-			Resources: []string{"test-dev-environment.yaml", "test-dev-rolebinding.yaml"},
+			Resources: []string{"argocd-admin.yaml", "test-dev-environment.yaml", "test-dev-rolebinding.yaml"},
 			Bases:     []string{"../../apps/my-app-1/overlays"},
 		},
 		"environments/test-dev/env/overlays/kustomization.yaml":                                    &res.Kustomization{Bases: []string{"../base"}},
@@ -154,6 +157,7 @@ func TestBuildEnvironmentsAddsKustomizedFiles(t *testing.T) {
 	}
 
 	want := []string{
+		"environments/test-dev/env/base/argocd-admin.yaml",
 		"environments/test-dev/env/base/kustomization.yaml",
 		"environments/test-dev/env/base/test-dev-environment.yaml",
 		"environments/test-dev/env/overlays/kustomization.yaml",
@@ -187,9 +191,10 @@ func TestBuildEnvironmentFilesWithNoCICDEnv(t *testing.T) {
 				vcsSourceLabel: "example/example",
 			},
 		},
+		"environments/test-dev/env/base/argocd-admin.yaml":                                         argocd.MakeApplicationControllerAdmin("test-dev"),
 		"environments/test-dev/apps/my-app-1/overlays/kustomization.yaml":                          &res.Kustomization{Bases: []string{"../base"}},
 		"environments/test-dev/env/base/test-dev-environment.yaml":                                 namespaces.Create("test-dev", testGitOpsRepoURL),
-		"environments/test-dev/env/base/kustomization.yaml":                                        &res.Kustomization{Resources: []string{"test-dev-environment.yaml"}},
+		"environments/test-dev/env/base/kustomization.yaml":                                        &res.Kustomization{Resources: []string{"argocd-admin.yaml", "test-dev-environment.yaml"}},
 		"environments/test-dev/env/overlays/kustomization.yaml":                                    &res.Kustomization{Bases: []string{"../base"}},
 		"environments/test-dev/apps/my-app-1/services/service-http/kustomization.yaml":             &res.Kustomization{Bases: []string{"overlays"}},
 		"environments/test-dev/apps/my-app-1/services/service-http/base/kustomization.yaml":        &res.Kustomization{Bases: []string{"./config"}},

--- a/pkg/pipelines/roles/service_rolebinding.go
+++ b/pkg/pipelines/roles/service_rolebinding.go
@@ -89,12 +89,18 @@ func CreateRole(name types.NamespacedName, policyRules []v1rbac.PolicyRule) *v1r
 	}
 }
 
+type clusterRoleOpts func(*v1rbac.ClusterRole)
+
 // CreateClusterRole creates and returns a ClusterRole given a name and policy
 // rules.
-func CreateClusterRole(name types.NamespacedName, policyRules []v1rbac.PolicyRule) *v1rbac.ClusterRole {
-	return &v1rbac.ClusterRole{
+func CreateClusterRole(name types.NamespacedName, policyRules []v1rbac.PolicyRule, opts ...clusterRoleOpts) *v1rbac.ClusterRole {
+	clusterRole := &v1rbac.ClusterRole{
 		TypeMeta:   clusterRoleTypeMeta,
 		ObjectMeta: meta.ObjectMeta(name),
 		Rules:      policyRules,
 	}
+	for _, opt := range opts {
+		opt(clusterRole)
+	}
+	return clusterRole
 }

--- a/pkg/pipelines/service_test.go
+++ b/pkg/pipelines/service_test.go
@@ -184,7 +184,7 @@ func TestServiceResourcesWithoutArgoCD(t *testing.T) {
 		"environments/test-dev/apps/test-app/overlays/kustomization.yaml": &res.Kustomization{
 			Bases: []string{"../base"}},
 		"environments/test-dev/env/base/kustomization.yaml": &res.Kustomization{
-			Resources: []string{"test-dev-environment.yaml"},
+			Resources: []string{"argocd-admin.yaml", "test-dev-environment.yaml"},
 			Bases:     []string{"../../apps/test-app/overlays"},
 		},
 		"pipelines.yaml": &config.Manifest{


### PR DESCRIPTION
**What type of PR is this?**
> /kind enhancement

**What does this PR do / why we need it**:
The Kam CLI should generate role bindings for each environment that makes argocd an admin in that environment. The rolebinding file `argocd-admin.yaml` will be generated during bootstrap and while adding environments

```shell
apiVersion: rbac.authorization.k8s.io/v1
kind: RoleBinding
metadata:
  creationTimestamp: null
  name: argocd-admin
  namespace: prod
roleRef:
  apiGroup: rbac.authorization.k8s.io
  kind: ClusterRole
  name: admin
subjects:
- kind: ServiceAccount
  name: argocd-cluster-argocd-application-controller
  namespace: openshift-gitops
```

It also generates a cluster role that aggregates sealed secrets to the OpenShift admin cluster role. This should be removed once it's fixed in upstream sealed secrets operator,

**Have you updated the necessary documentation?**

* [x] Documentation update is required by this PR.
* [x] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes https://issues.redhat.com/browse/GITOPS-500

**How to test changes / Special notes to the reviewer**:
1. Follow kam Day 1docs
2. Observe the following new files generated during bootstrap

* `config/cicd/base/02-rolebindings/argocd-admin.yaml` # make argocd admin in cicd environment
* `config/cicd/base/02-rolebindings/sealed-secrets-aggregate-to-admin.yaml` # add sealed secrets to admin cluster role 
* `environments/dev/env/base/argocd-admin.yaml` # make argocd admin in dev environment
*  `environments/stage/env/base/argocd-admin.yaml` # make argocd admin in stage environment
3. After applying resources, argocd should sync all the applications successfully without cluster-admin privileges