### PR TITLE
KAM to function without security manager

### DIFF
--- a/docs/commands/kam_bootstrap.md
+++ b/docs/commands/kam_bootstrap.md
@@ -27,6 +27,7 @@ kam bootstrap [flags]
       --gitops-webhook-secret string    Provide a secret that we can use to authenticate incoming hooks from your Git hosting service for the GitOps repository. (if not provided, it will be auto-generated)
   -h, --help                            help for bootstrap
       --image-repo string               Image repository of the form <registry>/<username>/<repository> or <project>/<app> which is used to push newly built images
+      --insecure                        Set to true to use unencrypted secrets instead of sealed secrets.
       --interactive                     If true, enable prompting for most options if not already specified on the command line
       --output string                   Path to write GitOps resources (default "./gitops")
       --overwrite                       Overwrites previously existing GitOps configuration (if any) on the local filesystem

--- a/docs/commands/kam_service.md
+++ b/docs/commands/kam_service.md
@@ -27,6 +27,7 @@ add
       --git-repo-url string         GitOps repository e.g. https://github.com/organisation/repository - only needed when you need to rebuild the source image for the environment
   -h, --help                        help for service
       --image-repo string           Image registry of the form <registry>/<username>/<image name> or <project>/<app> which is used to push newly built images
+      --insecure                    Set to true to use unencrypted secrets instead of sealed secrets.
       --pipelines-folder string     Folder path to retrieve manifest, eg. /test where manifest exists at /test/pipelines.yaml (default ".")
       --sealed-secrets-ns string    Namespace in which the Sealed Secrets operator is installed, automatically generated secrets are encrypted with this operator (default "cicd")
       --sealed-secrets-svc string   Name of the Sealed Secrets services that encrypts secrets (default "sealedsecretcontroller-sealed-secrets")

--- a/docs/commands/kam_service_add.md
+++ b/docs/commands/kam_service_add.md
@@ -25,6 +25,7 @@ kam service add [flags]
       --git-repo-url string         GitOps repository e.g. https://github.com/organisation/repository - only needed when you need to rebuild the source image for the environment
   -h, --help                        help for add
       --image-repo string           Image registry of the form <registry>/<username>/<image name> or <project>/<app> which is used to push newly built images
+      --insecure                    Set to true to use unencrypted secrets instead of sealed secrets.
       --pipelines-folder string     Folder path to retrieve manifest, eg. /test where manifest exists at /test/pipelines.yaml (default ".")
       --sealed-secrets-ns string    Namespace in which the Sealed Secrets operator is installed, automatically generated secrets are encrypted with this operator (default "cicd")
       --sealed-secrets-svc string   Name of the Sealed Secrets services that encrypts secrets (default "sealedsecretcontroller-sealed-secrets")

--- a/pkg/cmd/bootstrap_test.go
+++ b/pkg/cmd/bootstrap_test.go
@@ -280,7 +280,7 @@ func TestDependenciesWithNothingInstalled(t *testing.T) {
 	fakeClient := newFakeClient(nil, nil)
 
 	wantMsg := `
-Checking if Sealed Secrets is installed with the default configuration [Please install Sealed Secrets Operator from OperatorHub]
+Checking if Sealed Secrets is installed with the default configuration [The Sealed Secrets Operator was not detected]
 Checking if ArgoCD is installed with the default configuration [Please install OpenShift GitOps Operator from OperatorHub]
 Checking if OpenShift Pipelines Operator is installed with the default configuration [Please install OpenShift GitOps Operator from OperatorHub]`
 
@@ -321,7 +321,7 @@ func TestDependenciesWithAllInstalledDifferentSealedSecretsService(t *testing.T)
 
 	// expect negative Sealed Secrets check
 	wantMsg := `
-Checking if Sealed Secrets is installed with the default configuration [Please install Sealed Secrets Operator from OperatorHub]
+Checking if Sealed Secrets is installed with the default configuration [The Sealed Secrets Operator was not detected]
 Checking if ArgoCD is installed with the default configuration
 Checking if OpenShift Pipelines Operator is installed with the default configuration`
 

--- a/pkg/cmd/service/add.go
+++ b/pkg/cmd/service/add.go
@@ -2,6 +2,9 @@ package service
 
 import (
 	"fmt"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"os"
 
 	"github.com/openshift/odo/pkg/log"
 
@@ -28,6 +31,16 @@ var (
 	addShortDesc = `Add a new service`
 )
 
+var (
+	defaultSealedSecretsServiceName = types.NamespacedName{Namespace: secrets.SealedSecretsNS, Name: secrets.SealedSecretsController}
+)
+
+type status interface {
+	WarningStatus(status string)
+	Start(status string, debug bool)
+	End(status bool)
+}
+
 // AddServiceOptions encapsulates the parameters for service add command
 type AddServiceOptions struct {
 	*pipelines.AddServiceOptions
@@ -46,13 +59,51 @@ func (o *AddServiceOptions) Validate() error {
 
 // Run runs the project bootstrap command.
 func (o *AddServiceOptions) Run() error {
-	err := pipelines.AddService(o.AddServiceOptions, ioutils.NewFilesystem())
+	client, err := utility.NewClient()
+	if err := checkServiceDependencies(o, client, log.NewStatus(os.Stdout)); err != nil {
+		return err
+	}
+
+	err = pipelines.AddService(o.AddServiceOptions, ioutils.NewFilesystem())
 
 	if err != nil {
 		return err
 	}
 	log.Successf("Created Service %s successfully at environment %s.", o.ServiceName, o.EnvName)
 	return nil
+}
+
+func checkServiceDependencies(io *AddServiceOptions, client *utility.Client, spinner status) error {
+	spinner.Start("Checking if Sealed Secrets is installed with default configuration", false)
+	if err := checkAndSetSealedSecretsConfig(io, client, defaultSealedSecretsServiceName); err != nil {
+
+		warnIfNotFound(spinner, "The Sealed Secrets Operator was not detected", err)
+		io.Insecure = true
+		if !apierrors.IsNotFound(err) {
+			return fmt.Errorf("failed to check for Sealed Secrets Operator: %w", err)
+		}
+		utility.DisplayUnsealedSecretsWarning()
+		log.Progressf("  WARNING: Unencrypted secrets will be created in a secrets folder that is a sibling to the pipelines folder")
+		log.Progressf("           Deploying this GitOps configuration without encrypting secrets is insecure and is not recommended")
+	}
+	return nil
+}
+
+// check and remember the given Sealed Secrets configuration if is available otherwise return the error
+func checkAndSetSealedSecretsConfig(io *AddServiceOptions, client *utility.Client, sealedConfig types.NamespacedName) error {
+	if err := client.CheckIfSealedSecretsExists(sealedConfig); err != nil {
+		return err
+	} else {
+		io.SealedSecretsService = sealedConfig
+	}
+	return nil
+}
+
+func warnIfNotFound(spinner status, warningMsg string, err error) {
+	if apierrors.IsNotFound(err) {
+		spinner.WarningStatus(warningMsg)
+	}
+	spinner.End(false)
 }
 
 func newCmdAdd(name, fullName string) *cobra.Command {
@@ -78,6 +129,7 @@ func newCmdAdd(name, fullName string) *cobra.Command {
 
 	cmd.Flags().StringVar(&o.SealedSecretsService.Namespace, "sealed-secrets-ns", secrets.SealedSecretsNS, "Namespace in which the Sealed Secrets operator is installed, automatically generated secrets are encrypted with this operator")
 	cmd.Flags().StringVar(&o.SealedSecretsService.Name, "sealed-secrets-svc", secrets.SealedSecretsController, "Name of the Sealed Secrets services that encrypts secrets")
+	cmd.Flags().BoolVar(&o.Insecure, "insecure", false, "Set to true to use unencrypted secrets instead of sealed secrets.")
 
 	// required flags
 	_ = cmd.MarkFlagRequired("service-name")

--- a/pkg/cmd/ui/ui.go
+++ b/pkg/cmd/ui/ui.go
@@ -87,8 +87,9 @@ func EnterImageRepoExternalRepository() string {
 }
 
 // VerifyOutputPath allows the user to specify the path where the gitops configuration must reside locally in a UI prompt.
-func VerifyOutputPath(originalPath string, overwrite, outputPathOverridden, promptForPath bool) string {
+func VerifyOutputPath(originalPath string, overwrite, outputPathOverridden, promptForPath bool) (string, bool) {
 	var outputPath = originalPath
+	var doOverwrite = overwrite
 	prompt := &survey.Input{
 		Message: "Provide a path to write GitOps resources?",
 		Help:    "This is the path where the GitOps repository configuration is stored locally before you push it to the repository GitopsRepoURL",
@@ -104,14 +105,19 @@ func VerifyOutputPath(originalPath string, overwrite, outputPathOverridden, prom
 		if !exists || overwrite {
 			break
 		}
-		doOverwrite := SelectOptionOverwrite(outputPath)
+		doOverwrite = SelectOptionOverwrite(outputPath)
 		if doOverwrite {
 			break
 		}
 		handleError(survey.AskOne(prompt, &outputPath, nil))
 		outputPath = strings.TrimSpace(outputPath)
 	}
-	return outputPath
+	return outputPath, doOverwrite
+}
+
+func VerifySecretsPath(outputPath string) bool {
+	exists, _ := ioutils.IsExisting(ioutils.NewFilesystem(), filepath.Join(outputPath, "..", "secrets"))
+	return exists
 }
 
 // EnterGitWebhookSecret allows the user to specify the webhook secret string

--- a/pkg/cmd/utility/utility.go
+++ b/pkg/cmd/utility/utility.go
@@ -110,3 +110,8 @@ func (c *Client) CheckIfPipelinesExists(ns string) error {
 func GetFullName(parentName, name string) string {
 	return parentName + " " + name
 }
+
+func DisplayUnsealedSecretsWarning() {
+	log.Progressf("  WARNING: Unencrypted secrets will be created in a secrets folder that is a sibling to the designated output folder")
+	log.Progressf("           Deploying this GitOps configuration without encrypting secrets is insecure and is not recommended")
+}

--- a/pkg/pipelines/bootstrap.go
+++ b/pkg/pipelines/bootstrap.go
@@ -87,6 +87,7 @@ type BootstrapOptions struct {
 	ServiceWebhookSecret     string               // This is the secret for authenticating hooks from your app source.
 	PrivateRepoDriver        string               // Records the type of the GitOpsRepoURL driver if not a well-known host.
 	CommitStatusTracker      bool                 // If true, this is a "private repository", i.e. requires authentication to clone the repository.
+	Insecure                 bool                 // If true, use unencrypted, unsealed secrets. By default, sealed secrets are generated.
 }
 
 // PolicyRules to be bound to service account
@@ -137,7 +138,7 @@ func Bootstrap(o *BootstrapOptions, appFs afero.Fs) error {
 		return err
 	}
 
-	bootstrapped, err := bootstrapResources(o, appFs)
+	bootstrapped, otherResources, err := bootstrapResources(o, appFs)
 	if err != nil {
 		return fmt.Errorf("failed to bootstrap resources: %v", err)
 	}
@@ -151,6 +152,10 @@ func Bootstrap(o *BootstrapOptions, appFs afero.Fs) error {
 	bootstrapped = res.Merge(built, bootstrapped)
 	log.Successf("Created dev, stage and CICD environments")
 	_, err = yaml.WriteResources(appFs, o.OutputPath, bootstrapped)
+	if err != nil {
+		return fmt.Errorf("failed to write resources: %w", err)
+	}
+	_, err = yaml.WriteResources(appFs, filepath.Join(o.OutputPath, ".."), otherResources)
 	if err != nil {
 		return fmt.Errorf("failed to write resources: %w", err)
 	}
@@ -176,15 +181,15 @@ func maybeMakeHookSecrets(o *BootstrapOptions) error {
 	return nil
 }
 
-func bootstrapResources(o *BootstrapOptions, appFs afero.Fs) (res.Resources, error) {
+func bootstrapResources(o *BootstrapOptions, appFs afero.Fs) (res.Resources, res.Resources, error) {
 	ns := namespaces.NamesWithPrefix(o.Prefix)
 	appRepo, err := scm.NewRepository(o.ServiceRepoURL)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	repoName, err := repoFromURL(appRepo.URL())
 	if err != nil {
-		return nil, fmt.Errorf("invalid app repo URL: %v", err)
+		return nil, nil, fmt.Errorf("invalid app repo URL: %v", err)
 	}
 	// No image repo was supplied so create the default OS internal image registry
 	if o.ImageRepo == "" {
@@ -192,7 +197,7 @@ func bootstrapResources(o *BootstrapOptions, appFs afero.Fs) (res.Resources, err
 	}
 	isInternalRegistry, imageRepo, err := imagerepo.ValidateImageRepo(o.ImageRepo)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	log.Success("Options used:")
@@ -205,28 +210,29 @@ func bootstrapResources(o *BootstrapOptions, appFs afero.Fs) (res.Resources, err
 	log.Progressf("  Commit status tracker: %s", strconv.FormatBool(o.CommitStatusTracker))
 	log.Progressf("  Output folder: %s", o.OutputPath)
 	log.Progressf("  Overwrite output folder: %s", strconv.FormatBool(o.Overwrite))
+	log.Progressf("  Insecure: %s", strconv.FormatBool(o.Insecure))
 	log.Progressf("")
 
 	gitOpsRepo, err := scm.NewRepository(o.GitOpsRepoURL)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
-	bootstrapped, err := createInitialFiles(
+	bootstrapped, otherResources, err := createInitialFiles(
 		appFs, gitOpsRepo, o)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	appName := repoToAppName(repoName)
 	serviceName := repoName
 	secretName := secrets.MakeServiceWebhookSecretName(ns["dev"], serviceName)
 	envs, configEnv, err := bootstrapEnvironments(appRepo, o.Prefix, secretName, ns)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	if o.PrivateRepoDriver != "" {
 		host, err := scm.HostnameFromURL(o.GitOpsRepoURL)
 		if err != nil {
-			return nil, fmt.Errorf("failed to get hostname from URL %q: %w", o.GitOpsRepoURL, err)
+			return nil, nil, fmt.Errorf("failed to get hostname from URL %q: %w", o.GitOpsRepoURL, err)
 		}
 		configEnv.Git = &config.GitConfig{Drivers: map[string]string{host: o.PrivateRepoDriver}}
 	}
@@ -234,48 +240,64 @@ func bootstrapResources(o *BootstrapOptions, appFs afero.Fs) (res.Resources, err
 
 	devEnv := m.GetEnvironment(ns["dev"])
 	if devEnv == nil {
-		return nil, errors.New("unable to bootstrap without dev environment")
+		return nil, nil, errors.New("unable to bootstrap without dev environment")
 	}
 
 	app := m.GetApplication(ns["dev"], appName)
 	if app == nil {
-		return nil, errors.New("unable to bootstrap without application")
+		return nil, nil, errors.New("unable to bootstrap without application")
 	}
 	svcFiles, err := bootstrapServiceDeployment(devEnv, app)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create bootstrap service: %w", err)
+		return nil, nil, fmt.Errorf("failed to create bootstrap service: %w", err)
 	}
-	hookSecret, err := secrets.CreateSealedSecret(
-		meta.NamespacedName(ns["cicd"], secretName),
-		o.SealedSecretsService,
-		o.ServiceWebhookSecret,
-		eventlisteners.WebhookSecretKey)
-	if err != nil {
-		return nil, fmt.Errorf("failed to generate GitHub Webhook Secret: %v", err)
+	var hookSecret *ssv1alpha1.SealedSecret
+	var opaqueSecret *corev1.Secret
+	if !o.Insecure {
+		hookSecret, err = secrets.CreateSealedSecret(
+			meta.NamespacedName(ns["cicd"], secretName),
+			o.SealedSecretsService,
+			o.ServiceWebhookSecret,
+			eventlisteners.WebhookSecretKey)
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to generate GitHub Webhook Secret: %v", err)
+		}
+	} else {
+		opaqueSecret, err = secrets.CreateUnsealedSecret(meta.NamespacedName(ns["cicd"], secretName),
+			o.SealedSecretsService,
+			o.ServiceWebhookSecret,
+			eventlisteners.WebhookSecretKey)
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to create secret")
+		}
 	}
 
 	cfg := m.GetPipelinesConfig()
 	if cfg == nil {
-		return nil, errors.New("failed to find a pipeline configuration - unable to continue bootstrap")
+		return nil, nil, errors.New("failed to find a pipeline configuration - unable to continue bootstrap")
 	}
 	secretFilename := filepath.Join("03-secrets", secretName+".yaml")
-	secretsPath := filepath.Join(config.PathForPipelines(cfg), "base", secretFilename)
-	bootstrapped[secretsPath] = hookSecret
-
+	if !o.Insecure {
+		secretsPath := filepath.Join(config.PathForPipelines(cfg), "base", secretFilename)
+		bootstrapped[secretsPath] = hookSecret
+	} else {
+		secretFilename = filepath.Join("secrets", secretName+".yaml")
+		otherResources[secretFilename] = opaqueSecret
+	}
 	bindingName, imageRepoBindingFilename, svcImageBinding := createSvcImageBinding(cfg, devEnv, appName, serviceName, imageRepo, !isInternalRegistry)
 	bootstrapped = res.Merge(svcImageBinding, bootstrapped)
 
 	kustomizePath := filepath.Join(config.PathForPipelines(cfg), "base", "kustomization.yaml")
 	k, ok := bootstrapped[kustomizePath].(res.Kustomization)
 	if !ok {
-		return nil, fmt.Errorf("no kustomization for the %s environment found", kustomizePath)
+		return nil, nil, fmt.Errorf("no kustomization for the %s environment found", kustomizePath)
 	}
 	if isInternalRegistry {
 		filenames, resources, err := imagerepo.CreateInternalRegistryResources(
 			cfg, roles.CreateServiceAccount(meta.NamespacedName(cfg.Name, saName)),
 			imageRepo, o.GitOpsRepoURL)
 		if err != nil {
-			return nil, fmt.Errorf("failed to get resources for internal image repository: %v", err)
+			return nil, nil, fmt.Errorf("failed to get resources for internal image repository: %v", err)
 		}
 		bootstrapped = res.Merge(resources, bootstrapped)
 		k.AddResources(filenames...)
@@ -289,11 +311,14 @@ func bootstrapResources(o *BootstrapOptions, appFs afero.Fs) (res.Resources, err
 	}
 	bootstrapped[pipelinesFile] = m
 
-	k.AddResources(secretFilename, imageRepoBindingFilename)
+	if !o.Insecure {
+		k.AddResources(secretFilename)
+	}
+	k.AddResources(imageRepoBindingFilename)
 	bootstrapped[kustomizePath] = k
 
 	bootstrapped = res.Merge(svcFiles, bootstrapped)
-	return bootstrapped, nil
+	return bootstrapped, otherResources, nil
 }
 
 func bootstrapServiceDeployment(dev *config.Environment, app *config.Application) (res.Resources, error) {
@@ -437,19 +462,24 @@ func checkPipelinesFileExists(appFs afero.Fs, outputPath string, overWrite bool)
 	if exists && !overWrite {
 		return fmt.Errorf("pipelines.yaml in output path already exists. If you want to replace your existing files, please rerun with --overwrite")
 	}
+
+	secretsFolderExists, _ := ioutils.IsExisting(ioutils.NewFilesystem(), filepath.Join(outputPath, "..", "secrets"))
+	if secretsFolderExists && !overWrite {
+		return fmt.Errorf("the secrets folder located as a sibling of the output folder %s already exists. Rerun with --overwrite", outputPath)
+	}
 	return nil
 }
 
-func createInitialFiles(fs afero.Fs, repo scm.Repository, o *BootstrapOptions) (res.Resources, error) {
+func createInitialFiles(fs afero.Fs, repo scm.Repository, o *BootstrapOptions) (res.Resources, res.Resources, error) {
 	cicd := &config.PipelinesConfig{Name: o.Prefix + "cicd"}
 	pipelineConfig := &config.Config{Pipelines: cicd}
 	manifest := createManifest(repo.URL(), pipelineConfig)
 	initialFiles := res.Resources{
 		pipelinesFile: manifest,
 	}
-	resources, err := createCICDResources(fs, repo, cicd, o)
+	resources, otherResources, err := createCICDResources(fs, repo, cicd, o)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	files := getResourceFiles(resources)
@@ -461,71 +491,95 @@ func createInitialFiles(fs afero.Fs, repo scm.Repository, o *BootstrapOptions) (
 		getCICDKustomization(files))
 	initialFiles = res.Merge(pipelinesConfigKustomizations, initialFiles)
 
-	return initialFiles, nil
+	return initialFiles, otherResources, nil
 }
 
 // createDockerSecret creates a secret that allows pushing images to upstream repositories.
-func createDockerSecret(fs afero.Fs, dockerConfigJSONFilename, secretNS string, sealedSecretsService types.NamespacedName) (*ssv1alpha1.SealedSecret, error) {
+func createDockerSecret(fs afero.Fs, dockerConfigJSONFilename, secretNS string, sealedSecretsService types.NamespacedName, unencryptSecrets bool) (*ssv1alpha1.SealedSecret, *corev1.Secret, error) {
 	if dockerConfigJSONFilename == "" {
-		return nil, errors.New("failed to generate path to file: --dockerconfigjson flag is not provided")
+		return nil, nil, errors.New("failed to generate path to file: --dockerconfigjson flag is not provided")
 	}
 	authJSONPath, err := homedir.Expand(dockerConfigJSONFilename)
 	if err != nil {
-		return nil, fmt.Errorf("failed to generate path to file: %v", err)
+		return nil, nil, fmt.Errorf("failed to generate path to file: %v", err)
 	}
 	f, err := fs.Open(authJSONPath)
 	if err != nil {
-		return nil, fmt.Errorf("failed to read Docker config %#v : %s", authJSONPath, err)
+		return nil, nil, fmt.Errorf("failed to read Docker config %#v : %s", authJSONPath, err)
 	}
 	defer f.Close()
 
-	dockerSecret, err := secrets.CreateSealedDockerConfigSecret(meta.NamespacedName(secretNS, dockerSecretName), sealedSecretsService, f)
-	if err != nil {
-		return nil, err
+	if !unencryptSecrets {
+		dockerSecret, err := secrets.CreateSealedDockerConfigSecret(meta.NamespacedName(secretNS, dockerSecretName), sealedSecretsService, f)
+		if err != nil {
+			return nil, nil, err
+		}
+		return dockerSecret, nil, nil
+	} else {
+		dockerSecret, err := secrets.CreateUnsealedDockerConfigSecret(meta.NamespacedName(secretNS, dockerSecretName), sealedSecretsService, f)
+		if err != nil {
+			return nil, nil, err
+		}
+		return nil, dockerSecret, nil
 	}
-
-	return dockerSecret, nil
 }
 
 // createCICDResources creates resources for OpenShift pipelines.
-func createCICDResources(fs afero.Fs, repo scm.Repository, pipelineConfig *config.PipelinesConfig, o *BootstrapOptions) (res.Resources, error) {
+func createCICDResources(fs afero.Fs, repo scm.Repository, pipelineConfig *config.PipelinesConfig, o *BootstrapOptions) (res.Resources, res.Resources, error) {
 	cicdNamespace := pipelineConfig.Name
 	// key: path of the resource
 	// value: YAML content of the resource
 	outputs := map[string]interface{}{}
-	githubSecret, err := secrets.CreateSealedSecret(meta.NamespacedName(cicdNamespace, eventlisteners.GitOpsWebhookSecret),
-		o.SealedSecretsService, o.GitOpsWebhookSecret, eventlisteners.WebhookSecretKey)
-	if err != nil {
-		return nil, fmt.Errorf("failed to generate GitHub Webhook Secret: %w", err)
+	otherOutputs := map[string]interface{}{}
+	if !o.Insecure {
+		githubSecret, err := secrets.CreateSealedSecret(meta.NamespacedName(cicdNamespace, eventlisteners.GitOpsWebhookSecret),
+			o.SealedSecretsService, o.GitOpsWebhookSecret, eventlisteners.WebhookSecretKey)
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to generate GitHub Webhook Secret: %w", err)
+		}
+		outputs[secretsPath] = githubSecret
+	} else {
+		githubSecret, err := secrets.CreateUnsealedSecret(meta.NamespacedName(cicdNamespace, eventlisteners.GitOpsWebhookSecret),
+			o.SealedSecretsService, o.GitOpsWebhookSecret, eventlisteners.WebhookSecretKey)
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to generate GitHub Webhook Unsealed Secret: %w", err)
+		}
+		unEncSecretPath := filepath.Join("secrets", "gitops-webhook-secret.yaml")
+		otherOutputs[unEncSecretPath] = githubSecret
 	}
-	outputs[secretsPath] = githubSecret
 	outputs[namespacesPath] = namespaces.Create(cicdNamespace, o.GitOpsRepoURL)
 	outputs[rolesPath] = roles.CreateClusterRole(meta.NamespacedName("", roles.ClusterRoleName), Rules)
 
 	sa := roles.CreateServiceAccount(meta.NamespacedName(cicdNamespace, saName))
 
 	if o.DockerConfigJSONFilename != "" {
-		dockerSecret, err := createDockerSecret(fs, o.DockerConfigJSONFilename, cicdNamespace,
-			o.SealedSecretsService)
+		dockerSecret, dockerUnencryptedSecret, err := createDockerSecret(fs, o.DockerConfigJSONFilename, cicdNamespace,
+			o.SealedSecretsService, o.Insecure)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
-		outputs[dockerConfigPath] = dockerSecret
-		log.Success("Authentication tokens encrypted in secrets")
+		if dockerSecret != nil {
+			outputs[dockerConfigPath] = dockerSecret
+			log.Success("Authentication tokens encrypted in secrets")
+		}
+		if dockerUnencryptedSecret != nil {
+			otherOutputs[filepath.Join("secrets", "docker-config.yaml")] = dockerUnencryptedSecret
+			log.Success("Authentication tokens for docker config not sealed in secrets")
+		}
 		outputs[serviceAccountPath] = roles.AddSecretToSA(sa, dockerSecretName)
 	}
 
 	if o.GitHostAccessToken != "" {
-		err := generateSecrets(outputs, sa, cicdNamespace, o)
+		err := generateSecrets(outputs, otherOutputs, sa, cicdNamespace, o)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 	}
 
 	if o.CommitStatusTracker {
 		trackerResources, err := statustracker.Resources(cicdNamespace, o.GitOpsRepoURL, o.PrivateRepoDriver)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 		outputs = res.Merge(outputs, trackerResources)
 		log.Success("Pipelines tracker has been configured")
@@ -534,7 +588,7 @@ func createCICDResources(fs afero.Fs, repo scm.Repository, pipelineConfig *confi
 	outputs[rolebindingsPath] = roles.CreateClusterRoleBinding(meta.NamespacedName("", roleBindingName), sa, "ClusterRole", roles.ClusterRoleName)
 	script, err := dryrun.MakeScript("kubectl", cicdNamespace)
 	if err != nil {
-		return nil, err
+		return nil, otherOutputs, err
 	}
 	outputs[gitopsTasksPath] = tasks.CreateDeployFromSourceTask(cicdNamespace, script)
 	outputs[ciPipelinesPath] = pipelines.CreateCIPipeline(meta.NamespacedName(cicdNamespace, "ci-dryrun-from-push-pipeline"), cicdNamespace)
@@ -547,11 +601,11 @@ func createCICDResources(fs afero.Fs, repo scm.Repository, pipelineConfig *confi
 	log.Success("OpenShift Pipelines resources created")
 	route, err := eventlisteners.GenerateRoute(cicdNamespace)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	outputs[routePath] = route
 	log.Success("Openshift Route for EventListener created")
-	return outputs, nil
+	return outputs, otherOutputs, nil
 }
 
 func createManifest(gitOpsRepoURL string, configEnv *config.Config, envs ...*config.Environment) *config.Manifest {
@@ -595,28 +649,48 @@ func getResourceFiles(r res.Resources) []string {
 	return files
 }
 
-func generateSecrets(outputs res.Resources, sa *corev1.ServiceAccount, ns string, o *BootstrapOptions) error {
+func generateSecrets(outputs res.Resources, otherOutputs res.Resources, sa *corev1.ServiceAccount, ns string, o *BootstrapOptions) error {
 	if o.CommitStatusTracker {
-		tokenSecret, err := secrets.CreateSealedSecret(meta.NamespacedName(
-			ns, statustracker.CommitStatusTrackerSecret), o.SealedSecretsService, o.GitHostAccessToken, "token")
-		if err != nil {
-			return fmt.Errorf("failed to generate access token Secret: %w", err)
+		if !o.Insecure {
+			tokenSecret, err := secrets.CreateSealedSecret(meta.NamespacedName(
+				ns, statustracker.CommitStatusTrackerSecret), o.SealedSecretsService, o.GitHostAccessToken, "token")
+			if err != nil {
+				return fmt.Errorf("failed to generate access token Secret: %w", err)
+			}
+			outputs[authTokenPath] = tokenSecret
+			outputs[serviceAccountPath] = roles.AddSecretToSA(sa, tokenSecret.Name)
+		} else {
+			tokenSecret, err := secrets.CreateUnsealedSecret(meta.NamespacedName(
+				ns, statustracker.CommitStatusTrackerSecret), o.SealedSecretsService, o.GitHostAccessToken, "token")
+			if err != nil {
+				return fmt.Errorf("failed to generate unencrypted Secret: %w", err)
+			}
+			otherOutputs[filepath.Join("secrets", "git-host-access-token.yaml")] = tokenSecret
+			outputs[serviceAccountPath] = roles.AddSecretToSA(sa, tokenSecret.Name)
 		}
-		outputs[authTokenPath] = tokenSecret
-		outputs[serviceAccountPath] = roles.AddSecretToSA(sa, tokenSecret.Name)
 	}
 	secretTargetHost, err := repoURL(o.ServiceRepoURL)
 	if err != nil {
 		return fmt.Errorf("failed to parse the Service Repo URL %q: %w", o.ServiceRepoURL, err)
 	}
-	basicAuthSecret, err := secrets.CreateSealedBasicAuthSecret(meta.NamespacedName(
-		ns, "git-host-basic-auth-token"), o.SealedSecretsService, o.GitHostAccessToken, meta.AddAnnotations(map[string]string{
-		"tekton.dev/git-0": secretTargetHost,
-	}))
-	if err != nil {
-		return fmt.Errorf("failed to generate basic auth token Secret: %w", err)
+	if !o.Insecure {
+		basicAuthSecret, err := secrets.CreateSealedBasicAuthSecret(meta.NamespacedName(
+			ns, "git-host-basic-auth-token"), o.SealedSecretsService, o.GitHostAccessToken, meta.AddAnnotations(map[string]string{
+			"tekton.dev/git-0": secretTargetHost,
+		}))
+		if err != nil {
+			return fmt.Errorf("failed to generate basic auth token Secret: %w", err)
+		}
+		outputs[basicAuthTokenPath] = basicAuthSecret
+		outputs[serviceAccountPath] = roles.AddSecretToSA(sa, basicAuthSecret.Name)
+	} else {
+		basicAuthSecret, err := secrets.CreateUnsealedSecret(meta.NamespacedName(
+			ns, "git-host-basic-auth-token"), o.SealedSecretsService, o.GitHostAccessToken, "token")
+		if err != nil {
+			return fmt.Errorf("failed to generate unencrypted basic auth token Secret: %w", err)
+		}
+		otherOutputs[filepath.Join("secrets", "git-host-basic-auth-token.yaml")] = basicAuthSecret
+		outputs[serviceAccountPath] = roles.AddSecretToSA(sa, basicAuthSecret.Name)
 	}
-	outputs[basicAuthTokenPath] = basicAuthSecret
-	outputs[serviceAccountPath] = roles.AddSecretToSA(sa, basicAuthSecret.Name)
 	return nil
 }

--- a/pkg/pipelines/bootstrap_test.go
+++ b/pkg/pipelines/bootstrap_test.go
@@ -50,8 +50,12 @@ func TestBootstrapManifest(t *testing.T) {
 		ServiceWebhookSecret: "456",
 		CommitStatusTracker:  true,
 	}
-	r, err := bootstrapResources(params, ioutils.NewMemoryFilesystem())
+	r, otherResources, err := bootstrapResources(params, ioutils.NewMemoryFilesystem())
 	fatalIfError(t, err)
+
+	if diff := cmp.Diff(0, len(otherResources)); diff != "" {
+		t.Fatalf("other resources is not empty:\n%s", diff)
+	}
 
 	hookSecret, err := secrets.CreateSealedSecret(
 		meta.NamespacedName("tst-cicd", "webhook-secret-tst-dev-http-api"),
@@ -138,6 +142,139 @@ func TestBootstrapManifest(t *testing.T) {
 		"03-secrets/git-host-basic-auth-token.yaml",
 		"03-secrets/gitops-webhook-secret.yaml",
 		"03-secrets/webhook-secret-tst-dev-http-api.yaml",
+		"04-tasks/deploy-from-source-task.yaml",
+		"05-pipelines/app-ci-pipeline.yaml",
+		"05-pipelines/ci-dryrun-from-push-pipeline.yaml",
+		"06-bindings/github-push-binding.yaml",
+		"06-bindings/tst-dev-app-http-api-http-api-binding.yaml",
+		"07-templates/app-ci-build-from-push-template.yaml",
+		"07-templates/ci-dryrun-from-push-template.yaml",
+		"08-eventlisteners/cicd-event-listener.yaml",
+		"09-routes/gitops-webhook-event-listener.yaml",
+		"10-commit-status-tracker/operator.yaml",
+	}
+	k := r["config/tst-cicd/base/kustomization.yaml"].(res.Kustomization)
+	if diff := cmp.Diff(wantResources, k.Resources); diff != "" {
+		t.Fatalf("base kustomization failed:\n%s\n", diff)
+	}
+}
+
+func TestBootstrapManifestWithInsecureSecrets(t *testing.T) {
+	defer func(f secrets.PublicKeyFunc) {
+		secrets.DefaultPublicKeyFunc = f
+	}(secrets.DefaultPublicKeyFunc)
+
+	secrets.DefaultPublicKeyFunc = makeTestKey(t)
+
+	params := &BootstrapOptions{
+		Prefix:               "tst-",
+		GitOpsRepoURL:        testGitOpsRepo,
+		ImageRepo:            "image/repo",
+		GitOpsWebhookSecret:  "123",
+		GitHostAccessToken:   "test-token",
+		ServiceRepoURL:       testSvcRepo,
+		ServiceWebhookSecret: "456",
+		CommitStatusTracker:  true,
+		Insecure:             true,
+	}
+	r, otherResources, err := bootstrapResources(params, ioutils.NewMemoryFilesystem())
+	fatalIfError(t, err)
+
+	otherResourcesNotEmpty := 4
+	if diff := cmp.Diff(otherResourcesNotEmpty, len(otherResources)); diff != "" {
+		t.Fatalf("other resources is empty:\n%s", diff)
+	}
+
+	hookSecret, err := secrets.CreateUnsealedSecret(
+		meta.NamespacedName("tst-cicd", "webhook-secret-tst-dev-http-api"),
+		meta.NamespacedName("test-ns", "service"), "456", eventlisteners.WebhookSecretKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	svc := createBootstrapService("app-http-api", "tst-dev", "http-api")
+	route, err := routes.NewFromService(svc)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantOther := res.Resources{
+		"secrets/webhook-secret-tst-dev-http-api.yaml": hookSecret,
+	}
+	if diff := cmp.Diff(wantOther, otherResources, cmpopts.IgnoreMapEntries(func(k string, v interface{}) bool {
+		_, ok := wantOther[k]
+		return !ok
+	})); diff != "" {
+		t.Fatalf("bootstrapped resources:\n%s", diff)
+	}
+
+	want := res.Resources{
+		//"config/tst-cicd/base/03-secrets/webhook-secret-tst-dev-http-api.yaml": hookSecret,
+		"environments/tst-dev/apps/app-http-api/services/http-api/base/config/100-deployment.yaml": deployment.Create(
+			"app-http-api", "tst-dev", "http-api", bootstrapImage,
+			deployment.ContainerPort(8080)),
+		"environments/tst-dev/apps/app-http-api/services/http-api/base/config/200-service.yaml": svc,
+		"environments/tst-dev/apps/app-http-api/services/http-api/base/config/300-route.yaml":   route,
+		"environments/tst-dev/apps/app-http-api/services/http-api/base/config/kustomization.yaml": &res.Kustomization{
+			Resources: []string{"100-deployment.yaml", "200-service.yaml", "300-route.yaml"}},
+		pipelinesFile: &config.Manifest{
+			Version:   version,
+			GitOpsURL: "https://github.com/my-org/gitops.git",
+			Environments: []*config.Environment{
+				{
+					Pipelines: &config.Pipelines{
+						Integration: &config.TemplateBinding{
+							Template: "app-ci-template",
+							Bindings: []string{"github-push-binding"},
+						},
+					},
+					Name: "tst-dev",
+
+					Apps: []*config.Application{
+						{
+							Name: "app-http-api",
+							Services: []*config.Service{
+								{
+									Name:      "http-api",
+									SourceURL: testSvcRepo,
+									Webhook: &config.Webhook{
+										Secret: &config.Secret{
+											Name:      "webhook-secret-tst-dev-http-api",
+											Namespace: "tst-cicd",
+										},
+									},
+									Pipelines: &config.Pipelines{
+										Integration: &config.TemplateBinding{Bindings: []string{"tst-dev-app-http-api-http-api-binding", "github-push-binding"}},
+									},
+								},
+							},
+						},
+					},
+				},
+				{Name: "tst-stage"},
+			},
+			Config: &config.Config{
+				Pipelines: &config.PipelinesConfig{Name: "tst-cicd"},
+				ArgoCD:    &config.ArgoCDConfig{Namespace: argocd.ArgoCDNamespace},
+			},
+		},
+	}
+
+	if diff := cmp.Diff(want, r, cmpopts.IgnoreMapEntries(func(k string, v interface{}) bool {
+		_, ok := want[k]
+		return !ok
+	})); diff != "" {
+		t.Fatalf("bootstrapped resources:\n%s", diff)
+	}
+	// No secrets in output
+	wantResources := []string{
+		"01-namespaces/cicd-environment.yaml",
+		"01-namespaces/image-environment.yaml",
+		"02-rolebindings/commit-status-tracker-role.yaml",
+		"02-rolebindings/commit-status-tracker-rolebinding.yaml",
+		"02-rolebindings/commit-status-tracker-service-account.yaml",
+		"02-rolebindings/internal-registry-image-binding.yaml",
+		"02-rolebindings/pipeline-service-account.yaml",
+		"02-rolebindings/pipeline-service-role.yaml",
+		"02-rolebindings/pipeline-service-rolebinding.yaml",
 		"04-tasks/deploy-from-source-task.yaml",
 		"05-pipelines/app-ci-pipeline.yaml",
 		"05-pipelines/ci-dryrun-from-push-pipeline.yaml",
@@ -256,13 +393,13 @@ func TestInitialFiles(t *testing.T) {
 	fakeFs := ioutils.NewMemoryFilesystem()
 	repo, err := scm.NewRepository(gitOpsURL)
 	assertNoError(t, err)
-	got, err := createInitialFiles(fakeFs, repo, &o)
+	got, _, err := createInitialFiles(fakeFs, repo, &o)
 	assertNoError(t, err)
 
 	want := res.Resources{
 		pipelinesFile: createManifest(gitOpsURL, &config.Config{Pipelines: testpipelineConfig}),
 	}
-	resources, err := createCICDResources(fakeFs, repo, testpipelineConfig, &o)
+	resources, _, err := createCICDResources(fakeFs, repo, testpipelineConfig, &o)
 	if err != nil {
 		t.Fatalf("CreatePipelineResources() failed due to :%s\n", err)
 	}
@@ -322,6 +459,7 @@ func TestGenerateSecrets(t *testing.T) {
 	defer stubDefaultPublicKeyFunc(t)()
 	ns := "test-ns"
 	outputs := res.Resources{}
+	otherOutputs := res.Resources{}
 	sa := roles.CreateServiceAccount(meta.NamespacedName("test-ns", "test-sa"))
 	o := &BootstrapOptions{
 		SealedSecretsService: meta.NamespacedName("sealed-secrets", "secrets"),
@@ -330,7 +468,7 @@ func TestGenerateSecrets(t *testing.T) {
 		CommitStatusTracker:  true,
 	}
 
-	err := generateSecrets(outputs, sa, ns, o)
+	err := generateSecrets(outputs, otherOutputs, sa, ns, o)
 	fatalIfError(t, err)
 
 	wantSA := &corev1.ServiceAccount{
@@ -390,6 +528,7 @@ func TestGenerateSecretsWithNoCommitStatusTracker(t *testing.T) {
 	defer stubDefaultPublicKeyFunc(t)()
 	ns := "test-ns"
 	outputs := res.Resources{}
+	otherOutputs := res.Resources{}
 	sa := roles.CreateServiceAccount(meta.NamespacedName("test-ns", "test-sa"))
 	o := &BootstrapOptions{
 		SealedSecretsService: meta.NamespacedName("sealed-secrets", "secrets"),
@@ -398,7 +537,7 @@ func TestGenerateSecretsWithNoCommitStatusTracker(t *testing.T) {
 		CommitStatusTracker:  false,
 	}
 
-	err := generateSecrets(outputs, sa, ns, o)
+	err := generateSecrets(outputs, otherOutputs, sa, ns, o)
 	fatalIfError(t, err)
 
 	wantSA := &corev1.ServiceAccount{

--- a/pkg/pipelines/secrets/secrets.go
+++ b/pkg/pipelines/secrets/secrets.go
@@ -51,6 +51,15 @@ func CreateSealedDockerConfigSecret(name, service types.NamespacedName, in io.Re
 	return seal(secret, DefaultPublicKeyFunc, service)
 }
 
+// CreateUnsealedDockerConfigSecret creates a SealedSecret with the given name and reader
+func CreateUnsealedDockerConfigSecret(name, service types.NamespacedName, in io.Reader) (*corev1.Secret, error) {
+	secret, err := createDockerConfigSecret(name, in)
+	if err != nil {
+		return nil, err
+	}
+	return secret, nil
+}
+
 // CreateSealedSecret creates a SealedSecret with the provided name and body/data and type
 func CreateSealedSecret(name, service types.NamespacedName, data, secretKey string) (*ssv1alpha1.SealedSecret, error) {
 	secret, err := createOpaqueSecret(name, data, secretKey)
@@ -59,6 +68,14 @@ func CreateSealedSecret(name, service types.NamespacedName, data, secretKey stri
 	}
 
 	return seal(secret, DefaultPublicKeyFunc, service)
+}
+
+func CreateUnsealedSecret(name, service types.NamespacedName, data, secretKey string) (*corev1.Secret, error) {
+	secret, err := createOpaqueSecret(name, data, secretKey)
+	if err != nil {
+		return nil, err
+	}
+	return secret, nil
 }
 
 // CreateSealedBasicAuthSecret creates a SealedSecret with a BasicAuth type

--- a/pkg/pipelines/service.go
+++ b/pkg/pipelines/service.go
@@ -2,6 +2,8 @@ package pipelines
 
 import (
 	"fmt"
+	ssv1alpha1 "github.com/bitnami-labs/sealed-secrets/pkg/apis/sealed-secrets/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
 	"path/filepath"
 	"strconv"
 
@@ -30,6 +32,7 @@ type AddServiceOptions struct {
 	ServiceName          string
 	WebhookSecret        string
 	SealedSecretsService types.NamespacedName // SealedSecrets service name
+	Insecure             bool
 }
 
 // AddService is the entry-point from the CLI for adding new services.
@@ -38,12 +41,16 @@ func AddService(o *AddServiceOptions, appFs afero.Fs) error {
 	if err != nil {
 		return err
 	}
-	files, err := serviceResources(m, appFs, o)
+	files, otherResources, err := serviceResources(m, appFs, o)
 	if err != nil {
 		return err
 	}
 
 	_, err = yaml.WriteResources(appFs, o.PipelinesFolderPath, files)
+	if err != nil {
+		return err
+	}
+	_, err = yaml.WriteResources(appFs, filepath.Join(o.PipelinesFolderPath, ".."), otherResources)
 	if err != nil {
 		return err
 	}
@@ -62,31 +69,41 @@ func AddService(o *AddServiceOptions, appFs afero.Fs) error {
 	return nil
 }
 
-func serviceResources(m *config.Manifest, appFs afero.Fs, o *AddServiceOptions) (res.Resources, error) {
+func serviceResources(m *config.Manifest, appFs afero.Fs, o *AddServiceOptions) (res.Resources, res.Resources, error) {
 	files := res.Resources{}
+	otherResources := res.Resources{}
 	svc := createService(o.ServiceName, o.GitRepoURL)
 	cfg := m.GetPipelinesConfig()
 	if cfg != nil && o.WebhookSecret == "" && o.GitRepoURL != "" {
 		gitSecret, err := secrets.GenerateString(webhookSecretLength)
 		if err != nil {
-			return nil, fmt.Errorf("failed to generate service webhook secret: %v", err)
+			return nil, nil, fmt.Errorf("failed to generate service webhook secret: %v", err)
 		}
 		o.WebhookSecret = gitSecret
 	}
 
 	env := m.GetEnvironment(o.EnvName)
 	if env == nil {
-		return nil, fmt.Errorf("environment %s does not exist", o.EnvName)
+		return nil, nil, fmt.Errorf("environment %s does not exist", o.EnvName)
 	}
 
 	// add the secret only if CI/CD env is present
 	if cfg != nil {
 		secretName := secrets.MakeServiceWebhookSecretName(o.EnvName, svc.Name)
-		hookSecret, err := secrets.CreateSealedSecret(
-			meta.NamespacedName(cfg.Name, secretName), o.SealedSecretsService, o.WebhookSecret,
-			eventlisteners.WebhookSecretKey)
+		var hookSecret *ssv1alpha1.SealedSecret
+		var opaqueSecret *corev1.Secret
+		var err error
+		if !o.Insecure {
+			hookSecret, err = secrets.CreateSealedSecret(
+				meta.NamespacedName(cfg.Name, secretName), o.SealedSecretsService, o.WebhookSecret,
+				eventlisteners.WebhookSecretKey)
+		} else {
+			opaqueSecret, err = secrets.CreateUnsealedSecret(
+				meta.NamespacedName(cfg.Name, secretName), o.SealedSecretsService, o.WebhookSecret,
+				eventlisteners.WebhookSecretKey)
+		}
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 
 		svc.Webhook = &config.Webhook{
@@ -95,14 +112,19 @@ func serviceResources(m *config.Manifest, appFs afero.Fs, o *AddServiceOptions) 
 				Namespace: cfg.Name,
 			},
 		}
-		secretFilename := filepath.Join("03-secrets", secretName+".yaml")
-		secretsPath := filepath.Join(config.PathForPipelines(cfg), "base", secretFilename)
-		files[secretsPath] = hookSecret
+		if !o.Insecure {
+			secretFilename := filepath.Join("03-secrets", secretName+".yaml")
+			secretsPath := filepath.Join(config.PathForPipelines(cfg), "base", secretFilename)
+			files[secretsPath] = hookSecret
+		} else {
+			secretFilename := filepath.Join("secrets", secretName+".yaml")
+			otherResources[secretFilename] = opaqueSecret
+		}
 
 		if o.ImageRepo != "" && env.Pipelines != nil {
 			_, resources, bindingName, err := createImageRepoResources(m, cfg, env, o)
 			if err != nil {
-				return nil, err
+				return nil, nil, err
 			}
 
 			files = res.Merge(resources, files)
@@ -116,19 +138,19 @@ func serviceResources(m *config.Manifest, appFs afero.Fs, o *AddServiceOptions) 
 
 	err := m.AddService(o.EnvName, o.AppName, svc)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	err = m.Validate()
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	files[filepath.Base(filepath.Join(o.PipelinesFolderPath, pipelinesFile))] = m
 	built, err := buildResources(appFs, m)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
-	return res.Merge(built, files), nil
+	return res.Merge(built, files), otherResources, nil
 }
 
 func createImageRepoResources(m *config.Manifest, cfg *config.PipelinesConfig, env *config.Environment, p *AddServiceOptions) ([]string, res.Resources, string, error) {


### PR DESCRIPTION
Signed-off-by: Keith Chong <kykchong@redhat.com>

**What type of PR is this?**

/kind enhancement

**What does this PR do / why we need it**:
For those cases where customers did not install the Sealed Secrets Operator, we need KAM to still work without generating sealed secrets.  We will generate the unencrypted/unsealed secrets which can be secured separately.

**Have you updated the necessary documentation?**

* [x] Documentation update is required by this PR.
* [x] Documentation has been updated. See https://github.com/redhat-developer/kam/pull/182

**Which issue(s) this PR fixes**:
See https://issues.redhat.com/browse/GITOPS-677

**How to test changes / Special notes to the reviewer**:
Kevin wanted a new flag `--insecure` flag to give users the capability to force using unencrypted secrets and not by simply failing on the check that the sealed secrets operator is not installed.
