### PR TITLE
Executing kam bootstrap command

### DIFF
--- a/openshift-ci/build-root/Dockerfile
+++ b/openshift-ci/build-root/Dockerfile
@@ -2,7 +2,7 @@
 
 FROM registry.svc.ci.openshift.org/openshift/release:golang-1.14
 
-RUN yum -y install dnf httpd-tools sudo dbus-x11
+RUN yum -y install dnf httpd-tools sudo
 
 RUN mkdir -p $HOME/.ssh/
 

--- a/openshift-ci/build-root/Dockerfile
+++ b/openshift-ci/build-root/Dockerfile
@@ -2,7 +2,7 @@
 
 FROM registry.svc.ci.openshift.org/openshift/release:golang-1.14
 
-RUN yum -y install dnf httpd-tools sudo
+RUN yum -y install dnf httpd-tools sudo dbus-x11
 
 RUN mkdir -p $HOME/.ssh/
 

--- a/scripts/openshiftci-presubmit-all-tests.sh
+++ b/scripts/openshiftci-presubmit-all-tests.sh
@@ -11,6 +11,23 @@ export KUBEADMIN_PASSWORD=`cat $KUBEADMIN_PASSWORD_FILE`
 # show commands
 set -x
 export CI="prow"
+if ! [[ -w ${HOME:-} ]]; then
+    export HOME=/alabama;
+fi
+mkdir -p -m 700 ~/.ssh/
+cp $KAM_SSH_PRIVATE_KEY_FILE ~/.ssh/
+cp $KAM_SSH_PUBLIC_KEY_FILE ~/.ssh/
+echo -e "Host github.com\n\tStrictHostKeyChecking no\n" >> ~/.ssh/config
+chmod 600 ~/.ssh/config
+ls -lr ~/.ssh/
+
+sudo mkdir -p -m 700 /.ssh/
+sudo cp $KAM_SSH_PRIVATE_KEY_FILE /.ssh/
+sudo cp $KAM_SSH_PUBLIC_KEY_FILE /.ssh/
+sudo echo -e "Host github.com\n\tStrictHostKeyChecking no\n" >> /.ssh/config
+sudo chmod 600 /.ssh/config
+sudo ls -lr /.ssh/
+
 go mod vendor
 export PRNO="$(jq .refs.pulls[0].number <<< $(echo $JOB_SPEC))"
 make prepare-test-cluster

--- a/scripts/openshiftci-presubmit-all-tests.sh
+++ b/scripts/openshiftci-presubmit-all-tests.sh
@@ -11,6 +11,7 @@ export GITHUB_TOKEN=`cat $KAM_GITHUB_TOKEN_FILE`
 set -x
 export CI="prow"
 go mod vendor
+export PRNO="$(jq .refs.pulls[0].number <<< $(echo $JOB_SPEC))"
 make prepare-test-cluster
 make bin
 

--- a/scripts/openshiftci-presubmit-all-tests.sh
+++ b/scripts/openshiftci-presubmit-all-tests.sh
@@ -6,6 +6,7 @@ set -e
 # Do not show token in CI log
 set +x
 export GITHUB_TOKEN=`cat $KAM_GITHUB_TOKEN_FILE`
+export KUBEADMIN_PASSWORD=`cat $KUBEADMIN_PASSWORD_FILE`
 
 # show commands
 set -x
@@ -31,6 +32,9 @@ TMP_DIR=$(mktemp -d)
 cp $KUBECONFIG $TMP_DIR/kubeconfig
 chmod 640 $TMP_DIR/kubeconfig
 export KUBECONFIG=$TMP_DIR/kubeconfig
+
+# login as kube:admin
+oc login -u kubeadmin -p $KUBEADMIN_PASSWORD
 
 # # Login as developer
 # oc login -u developer -p developer

--- a/scripts/openshiftci-presubmit-all-tests.sh
+++ b/scripts/openshiftci-presubmit-all-tests.sh
@@ -32,18 +32,18 @@ cp $KUBECONFIG $TMP_DIR/kubeconfig
 chmod 640 $TMP_DIR/kubeconfig
 export KUBECONFIG=$TMP_DIR/kubeconfig
 
-# Login as developer
-oc login -u developer -p developer
+# # Login as developer
+# oc login -u developer -p developer
 
 # Check login user name for debugging purpose
 oc whoami
-login_user=`oc whoami`
-if [[ $login_user == *"developer"* ]]; then
-    echo "Login to the cluster as a developer user"
-else
-    echo "Fail to login as a developer user"
-    exit 1
-fi
+# login_user=`oc whoami`
+# if [[ $login_user == *"developer"* ]]; then
+#     echo "Login to the cluster as a developer user"
+# else
+#     echo "Fail to login as a developer user"
+#     exit 1
+# fi
 
 # assert that kam is on the path
 kam version

--- a/scripts/openshiftci-presubmit-all-tests.sh
+++ b/scripts/openshiftci-presubmit-all-tests.sh
@@ -28,10 +28,10 @@ export CUSTOM_HOMEDIR=$ARTIFACTS_DIR
 
 # Copy kubeconfig to temporary kubeconfig file and grant
 # read and Write permission to temporary kubeconfig file
-# TMP_DIR=$(mktemp -d)
-# cp $KUBECONFIG $TMP_DIR/kubeconfig
-# chmod 640 $TMP_DIR/kubeconfig
-# export KUBECONFIG=$TMP_DIR/kubeconfig
+TMP_DIR=$(mktemp -d)
+cp $KUBECONFIG $TMP_DIR/kubeconfig
+chmod 640 $TMP_DIR/kubeconfig
+export KUBECONFIG=$TMP_DIR/kubeconfig
 
 # login as kube:admin
 oc login -u kubeadmin -p $KUBEADMIN_PASSWORD
@@ -51,8 +51,6 @@ oc whoami
 
 # assert that kam is on the path
 kam version
-
-oc get service -n cicd
 
 # Run e2e test
 make e2e

--- a/scripts/openshiftci-presubmit-all-tests.sh
+++ b/scripts/openshiftci-presubmit-all-tests.sh
@@ -11,6 +11,10 @@ export KUBEADMIN_PASSWORD=`cat $KUBEADMIN_PASSWORD_FILE`
 # show commands
 set -x
 export CI="prow"
+if ! [[ -w ${HOME:-} ]]; then
+    export HOME=/alabama;
+fi
+echo $HOME
 go mod vendor
 export PRNO="$(jq .refs.pulls[0].number <<< $(echo $JOB_SPEC))"
 make prepare-test-cluster

--- a/scripts/openshiftci-presubmit-all-tests.sh
+++ b/scripts/openshiftci-presubmit-all-tests.sh
@@ -50,6 +50,8 @@ else
     exit 1
 fi
 
+gh auth login --with-token < $KAM_GITHUB_TOKEN_FILE
+
 # assert that kam is on the path
 kam version
 

--- a/scripts/openshiftci-presubmit-all-tests.sh
+++ b/scripts/openshiftci-presubmit-all-tests.sh
@@ -28,10 +28,10 @@ export CUSTOM_HOMEDIR=$ARTIFACTS_DIR
 
 # Copy kubeconfig to temporary kubeconfig file and grant
 # read and Write permission to temporary kubeconfig file
-TMP_DIR=$(mktemp -d)
-cp $KUBECONFIG $TMP_DIR/kubeconfig
-chmod 640 $TMP_DIR/kubeconfig
-export KUBECONFIG=$TMP_DIR/kubeconfig
+# TMP_DIR=$(mktemp -d)
+# cp $KUBECONFIG $TMP_DIR/kubeconfig
+# chmod 640 $TMP_DIR/kubeconfig
+# export KUBECONFIG=$TMP_DIR/kubeconfig
 
 # login as kube:admin
 oc login -u kubeadmin -p $KUBEADMIN_PASSWORD

--- a/scripts/openshiftci-presubmit-all-tests.sh
+++ b/scripts/openshiftci-presubmit-all-tests.sh
@@ -11,10 +11,6 @@ export KUBEADMIN_PASSWORD=`cat $KUBEADMIN_PASSWORD_FILE`
 # show commands
 set -x
 export CI="prow"
-if ! [[ -w ${HOME:-} ]]; then
-    export HOME=/alabama;
-fi
-echo $HOME
 go mod vendor
 export PRNO="$(jq .refs.pulls[0].number <<< $(echo $JOB_SPEC))"
 make prepare-test-cluster
@@ -49,8 +45,6 @@ else
     echo "Fail to login as a admin user"
     exit 1
 fi
-
-gh auth login --with-token < $KAM_GITHUB_TOKEN_FILE
 
 # assert that kam is on the path
 kam version

--- a/scripts/openshiftci-presubmit-all-tests.sh
+++ b/scripts/openshiftci-presubmit-all-tests.sh
@@ -11,23 +11,6 @@ export KUBEADMIN_PASSWORD=`cat $KUBEADMIN_PASSWORD_FILE`
 # show commands
 set -x
 export CI="prow"
-if ! [[ -w ${HOME:-} ]]; then
-    export HOME=/alabama;
-fi
-mkdir -p -m 700 ~/.ssh/
-cp $KAM_SSH_PRIVATE_KEY_FILE ~/.ssh/
-cp $KAM_SSH_PUBLIC_KEY_FILE ~/.ssh/
-echo -e "Host github.com\n\tStrictHostKeyChecking no\n" >> ~/.ssh/config
-chmod 600 ~/.ssh/config
-ls -lr ~/.ssh/
-
-sudo mkdir -p -m 700 /.ssh/
-sudo cp $KAM_SSH_PRIVATE_KEY_FILE /.ssh/
-sudo cp $KAM_SSH_PUBLIC_KEY_FILE /.ssh/
-sudo echo -e "Host github.com\n\tStrictHostKeyChecking no\n" >> /.ssh/config
-sudo chmod 600 /.ssh/config
-sudo ls -lr /.ssh/
-
 go mod vendor
 export PRNO="$(jq .refs.pulls[0].number <<< $(echo $JOB_SPEC))"
 make prepare-test-cluster
@@ -49,6 +32,17 @@ TMP_DIR=$(mktemp -d)
 cp $KUBECONFIG $TMP_DIR/kubeconfig
 chmod 640 $TMP_DIR/kubeconfig
 export KUBECONFIG=$TMP_DIR/kubeconfig
+
+gitconfig=`cat <<'EOF'
+[user]
+name = Kam Bot
+email = kambotuser@gmail.com
+[credential "https://github.com"]
+username = kam-bot
+helper = "!f() { test \"$1\" = get && echo \"password=$(cat $KAM_GITHUB_TOKEN_FILE)\"; }; f"
+EOF
+`
+echo "$gitconfig" >> ~/.gitconfig
 
 # login as kube:admin
 oc login -u kubeadmin -p $KUBEADMIN_PASSWORD

--- a/scripts/openshiftci-presubmit-all-tests.sh
+++ b/scripts/openshiftci-presubmit-all-tests.sh
@@ -33,17 +33,6 @@ cp $KUBECONFIG $TMP_DIR/kubeconfig
 chmod 640 $TMP_DIR/kubeconfig
 export KUBECONFIG=$TMP_DIR/kubeconfig
 
-gitconfig=`cat <<'EOF'
-[user]
-name = Kam Bot
-email = kambotuser@gmail.com
-[credential "https://github.com"]
-username = kam-bot
-helper = "!f() { test \"$1\" = get && echo \"password=$(cat $KAM_GITHUB_TOKEN_FILE)\"; }; f"
-EOF
-`
-echo "$gitconfig" >> ~/.gitconfig
-
 # login as kube:admin
 oc login -u kubeadmin -p $KUBEADMIN_PASSWORD
 

--- a/scripts/openshiftci-presubmit-all-tests.sh
+++ b/scripts/openshiftci-presubmit-all-tests.sh
@@ -27,10 +27,10 @@ export CUSTOM_HOMEDIR=$ARTIFACTS_DIR
 
 # Copy kubeconfig to temporary kubeconfig file and grant
 # read and Write permission to temporary kubeconfig file
-# TMP_DIR=$(mktemp -d)
-# cp $KUBECONFIG $TMP_DIR/kubeconfig
-# chmod 640 $TMP_DIR/kubeconfig
-# export KUBECONFIG=$TMP_DIR/kubeconfig
+TMP_DIR=$(mktemp -d)
+cp $KUBECONFIG $TMP_DIR/kubeconfig
+chmod 640 $TMP_DIR/kubeconfig
+export KUBECONFIG=$TMP_DIR/kubeconfig
 
 # # Login as developer
 # oc login -u developer -p developer

--- a/scripts/openshiftci-presubmit-all-tests.sh
+++ b/scripts/openshiftci-presubmit-all-tests.sh
@@ -48,5 +48,7 @@ oc whoami
 # assert that kam is on the path
 kam version
 
+oc get service -n cicd
+
 # Run e2e test
 make e2e

--- a/scripts/openshiftci-presubmit-all-tests.sh
+++ b/scripts/openshiftci-presubmit-all-tests.sh
@@ -27,10 +27,10 @@ export CUSTOM_HOMEDIR=$ARTIFACTS_DIR
 
 # Copy kubeconfig to temporary kubeconfig file and grant
 # read and Write permission to temporary kubeconfig file
-TMP_DIR=$(mktemp -d)
-cp $KUBECONFIG $TMP_DIR/kubeconfig
-chmod 640 $TMP_DIR/kubeconfig
-export KUBECONFIG=$TMP_DIR/kubeconfig
+# TMP_DIR=$(mktemp -d)
+# cp $KUBECONFIG $TMP_DIR/kubeconfig
+# chmod 640 $TMP_DIR/kubeconfig
+# export KUBECONFIG=$TMP_DIR/kubeconfig
 
 # # Login as developer
 # oc login -u developer -p developer

--- a/scripts/openshiftci-presubmit-all-tests.sh
+++ b/scripts/openshiftci-presubmit-all-tests.sh
@@ -40,18 +40,15 @@ export KUBECONFIG=$TMP_DIR/kubeconfig
 # login as kube:admin
 oc login -u kubeadmin -p $KUBEADMIN_PASSWORD
 
-# # Login as developer
-# oc login -u developer -p developer
-
 # Check login user name for debugging purpose
 oc whoami
-# login_user=`oc whoami`
-# if [[ $login_user == *"developer"* ]]; then
-#     echo "Login to the cluster as a developer user"
-# else
-#     echo "Fail to login as a developer user"
-#     exit 1
-# fi
+login_user=`oc whoami`
+if [[ $login_user == *"admin"* ]]; then
+    echo "Login to the cluster as a admin user"
+else
+    echo "Fail to login as a admin user"
+    exit 1
+fi
 
 # assert that kam is on the path
 kam version

--- a/scripts/openshiftci-presubmit-unittests.sh
+++ b/scripts/openshiftci-presubmit-unittests.sh
@@ -2,6 +2,7 @@
 
 # fail if some commands fails
 set -e
+
 # show commands
 set -x
 

--- a/scripts/prepare-test-cluster.sh
+++ b/scripts/prepare-test-cluster.sh
@@ -2,16 +2,16 @@
 set -x
 # Setup to find necessary data from cluster setup
 # Constants
-HTPASSWD_FILE="./htpass"
-USERPASS="developer"
-HTPASSWD_SECRET="htpasswd-secret"
+# HTPASSWD_FILE="./htpass"
+# USERPASS="developer"
+# HTPASSWD_SECRET="htpasswd-secret"
 SETUP_OPERATORS="./scripts/setup-operators.sh"
 # Overrideable information
 DEFAULT_INSTALLER_ASSETS_DIR=${DEFAULT_INSTALLER_ASSETS_DIR:-$(pwd)}
 KUBEADMIN_USER=${KUBEADMIN_USER:-"kubeadmin"}
 KUBEADMIN_PASSWORD_FILE=${KUBEADMIN_PASSWORD_FILE:-"${DEFAULT_INSTALLER_ASSETS_DIR}/auth/kubeadmin-password"}
 # Default values
-OC_LOGIN_SUCCEEDED="false"
+# OC_LOGIN_SUCCEEDED="false"
 # Exported to current env
 ORIGINAL_KUBECONFIG=${KUBECONFIG:-"${DEFAULT_INSTALLER_ASSETS_DIR}/auth/kubeconfig"}
 export KUBECONFIG=$ORIGINAL_KUBECONFIG
@@ -37,13 +37,13 @@ if [ -z $CI ]; then
 
     # Login as admin user
     oc login -u $KUBEADMIN_USER -p $KUBEADMIN_PASSWORD
-# else
-#     # Copy kubeconfig to temporary kubeconfig file
-#     # Read and Write permission to temporary kubeconfig file
-#     TMP_DIR=$(mktemp -d)
-#     cp $KUBECONFIG $TMP_DIR/kubeconfig
-#     chmod 640 $TMP_DIR/kubeconfig
-#     export KUBECONFIG=$TMP_DIR/kubeconfig
+else
+    # Copy kubeconfig to temporary kubeconfig file
+    # Read and Write permission to temporary kubeconfig file
+    TMP_DIR=$(mktemp -d)
+    cp $KUBECONFIG $TMP_DIR/kubeconfig
+    chmod 640 $TMP_DIR/kubeconfig
+    export KUBECONFIG=$TMP_DIR/kubeconfig
 fi
 
 # Create the namespace for operator installation namespace
@@ -126,8 +126,8 @@ oc version
 # Project list
 oc projects
 
-# # KUBECONFIG cleanup only if CI is set
-# if [ ! -f $CI ]; then
-#     rm -rf $KUBECONFIG
-#     export KUBECONFIG=$ORIGINAL_KUBECONFIG
-# fi
+# KUBECONFIG cleanup only if CI is set
+if [ ! -f $CI ]; then
+    rm -rf $KUBECONFIG
+    export KUBECONFIG=$ORIGINAL_KUBECONFIG
+fi

--- a/scripts/prepare-test-cluster.sh
+++ b/scripts/prepare-test-cluster.sh
@@ -37,88 +37,88 @@ if [ -z $CI ]; then
 
     # Login as admin user
     oc login -u $KUBEADMIN_USER -p $KUBEADMIN_PASSWORD
-else
-    # Copy kubeconfig to temporary kubeconfig file
-    # Read and Write permission to temporary kubeconfig file
-    TMP_DIR=$(mktemp -d)
-    cp $KUBECONFIG $TMP_DIR/kubeconfig
-    chmod 640 $TMP_DIR/kubeconfig
-    export KUBECONFIG=$TMP_DIR/kubeconfig
+# else
+#     # Copy kubeconfig to temporary kubeconfig file
+#     # Read and Write permission to temporary kubeconfig file
+#     TMP_DIR=$(mktemp -d)
+#     cp $KUBECONFIG $TMP_DIR/kubeconfig
+#     chmod 640 $TMP_DIR/kubeconfig
+#     export KUBECONFIG=$TMP_DIR/kubeconfig
 fi
 
 # Create the namespace for operator installation namespace
 for i in `echo $OPERATOR_NAMESPACES`; do
     # create the namespace
     oc new-project $i
-    # Let developer user have access to the project
-    oc adm policy add-role-to-user edit developer
+    # # Let developer user have access to the project
+    # oc adm policy add-role-to-user edit developer
 done
 
 # Setup the cluster for sealed secrets and OpenShift GitOps operator
 sh $SETUP_OPERATORS
 
-# Remove existing htpasswd file, if any
-if [ -f $HTPASSWD_FILE ]; then
-    rm -rf $HTPASSWD_FILE
-fi
+# # Remove existing htpasswd file, if any
+# if [ -f $HTPASSWD_FILE ]; then
+#     rm -rf $HTPASSWD_FILE
+# fi
 
-# Set so first time -c parameter gets applied to htpasswd
-HTPASSWD_CREATED=" -c "
+# # Set so first time -c parameter gets applied to htpasswd
+# HTPASSWD_CREATED=" -c "
 
-# Create htpasswd entries for developer
-htpasswd -b $HTPASSWD_CREATED $HTPASSWD_FILE developer $USERPASS
-HTPASSWD_CREATED=""
+# # Create htpasswd entries for developer
+# htpasswd -b $HTPASSWD_CREATED $HTPASSWD_FILE developer $USERPASS
+# HTPASSWD_CREATED=""
 
-# Create secret in cluster and replace
-oc create secret generic ${HTPASSWD_SECRET} --from-file=htpasswd=${HTPASSWD_FILE} -n openshift-config --dry-run=client -o yaml | oc apply -f -
+# # Create secret in cluster and replace
+# oc create secret generic ${HTPASSWD_SECRET} --from-file=htpasswd=${HTPASSWD_FILE} -n openshift-config --dry-run=client -o yaml | oc apply -f -
 
-# Upload htpasswd as new login config
-oc apply -f - <<EOF
-apiVersion: config.openshift.io/v1
-kind: OAuth
-metadata:
-  name: cluster
-spec:
-  identityProviders:
-  - name: htpassidp1
-    challenge: true
-    login: true
-    mappingMethod: claim
-    type: HTPasswd
-    htpasswd:
-      fileData:
-        name: ${HTPASSWD_SECRET}
-EOF
+# # Upload htpasswd as new login config
+# oc apply -f - <<EOF
+# apiVersion: config.openshift.io/v1
+# kind: OAuth
+# metadata:
+#   name: cluster
+# spec:
+#   identityProviders:
+#   - name: htpassidp1
+#     challenge: true
+#     login: true
+#     mappingMethod: claim
+#     type: HTPasswd
+#     htpasswd:
+#       fileData:
+#         name: ${HTPASSWD_SECRET}
+# EOF
 
-# Login as developer and check for stable server
-for i in {1..40}; do
-    # Try logging in as developer
-    oc login -u developer -p $USERPASS &> /dev/null
-    if [ $? -eq 0 ]; then
-        # If login succeeds, assume success
-	    OC_LOGIN_SUCCEEDED="true"
-        # Attempt failure of `oc whoami`
-        for j in {1..25}; do
-            oc whoami &> /dev/null
-            if [ $? -ne 0 ]; then
-                # If `oc whoami` fails, assume fail and break out of trying `oc whoami`
-                OC_LOGIN_SUCCEEDED="false"
-                break
-            fi
-            sleep 2
-        done
-        # If `oc whoami` never failed, break out trying to login again
-        if [ $OC_LOGIN_SUCCEEDED == "true" ]; then
-            break
-        fi
-    fi
-    sleep 3
-done
+# # Login as developer and check for stable server
+# for i in {1..40}; do
+#     # Try logging in as developer
+#     oc login -u developer -p $USERPASS &> /dev/null
+#     if [ $? -eq 0 ]; then
+#         # If login succeeds, assume success
+# 	    OC_LOGIN_SUCCEEDED="true"
+#         # Attempt failure of `oc whoami`
+#         for j in {1..25}; do
+#             oc whoami &> /dev/null
+#             if [ $? -ne 0 ]; then
+#                 # If `oc whoami` fails, assume fail and break out of trying `oc whoami`
+#                 OC_LOGIN_SUCCEEDED="false"
+#                 break
+#             fi
+#             sleep 2
+#         done
+#         # If `oc whoami` never failed, break out trying to login again
+#         if [ $OC_LOGIN_SUCCEEDED == "true" ]; then
+#             break
+#         fi
+#     fi
+#     sleep 3
+# done
 
-if [ $OC_LOGIN_SUCCEEDED == "false" ]; then
-    echo "Failed to login as developer"
-    exit 1
-fi
+# if [ $OC_LOGIN_SUCCEEDED == "false" ]; then
+#     echo "Failed to login as developer"
+#     exit 1
+# fi
 
 # Client version
 oc version
@@ -126,8 +126,8 @@ oc version
 # Project list
 oc projects
 
-# KUBECONFIG cleanup only if CI is set
-if [ ! -f $CI ]; then
-    rm -rf $KUBECONFIG
-    export KUBECONFIG=$ORIGINAL_KUBECONFIG
-fi
+# # KUBECONFIG cleanup only if CI is set
+# if [ ! -f $CI ]; then
+#     rm -rf $KUBECONFIG
+#     export KUBECONFIG=$ORIGINAL_KUBECONFIG
+# fi

--- a/scripts/prepare-test-cluster.sh
+++ b/scripts/prepare-test-cluster.sh
@@ -37,13 +37,13 @@ if [ -z $CI ]; then
 
     # Login as admin user
     oc login -u $KUBEADMIN_USER -p $KUBEADMIN_PASSWORD
-else
-    # Copy kubeconfig to temporary kubeconfig file
-    # Read and Write permission to temporary kubeconfig file
-    TMP_DIR=$(mktemp -d)
-    cp $KUBECONFIG $TMP_DIR/kubeconfig
-    chmod 640 $TMP_DIR/kubeconfig
-    export KUBECONFIG=$TMP_DIR/kubeconfig
+# else
+#     # Copy kubeconfig to temporary kubeconfig file
+#     # Read and Write permission to temporary kubeconfig file
+#     TMP_DIR=$(mktemp -d)
+#     cp $KUBECONFIG $TMP_DIR/kubeconfig
+#     chmod 640 $TMP_DIR/kubeconfig
+#     export KUBECONFIG=$TMP_DIR/kubeconfig
 fi
 
 # Create the namespace for operator installation namespace
@@ -127,7 +127,7 @@ oc version
 oc projects
 
 # KUBECONFIG cleanup only if CI is set
-if [ ! -f $CI ]; then
-    rm -rf $KUBECONFIG
-    export KUBECONFIG=$ORIGINAL_KUBECONFIG
-fi
+# if [ ! -f $CI ]; then
+#     rm -rf $KUBECONFIG
+#     export KUBECONFIG=$ORIGINAL_KUBECONFIG
+# fi

--- a/scripts/prepare-test-cluster.sh
+++ b/scripts/prepare-test-cluster.sh
@@ -37,13 +37,13 @@ if [ -z $CI ]; then
 
     # Login as admin user
     oc login -u $KUBEADMIN_USER -p $KUBEADMIN_PASSWORD
-# else
-#     # Copy kubeconfig to temporary kubeconfig file
-#     # Read and Write permission to temporary kubeconfig file
-#     TMP_DIR=$(mktemp -d)
-#     cp $KUBECONFIG $TMP_DIR/kubeconfig
-#     chmod 640 $TMP_DIR/kubeconfig
-#     export KUBECONFIG=$TMP_DIR/kubeconfig
+else
+    # Copy kubeconfig to temporary kubeconfig file
+    # Read and Write permission to temporary kubeconfig file
+    TMP_DIR=$(mktemp -d)
+    cp $KUBECONFIG $TMP_DIR/kubeconfig
+    chmod 640 $TMP_DIR/kubeconfig
+    export KUBECONFIG=$TMP_DIR/kubeconfig
 fi
 
 # Create the namespace for operator installation namespace
@@ -127,7 +127,7 @@ oc version
 oc projects
 
 # KUBECONFIG cleanup only if CI is set
-# if [ ! -f $CI ]; then
-#     rm -rf $KUBECONFIG
-#     export KUBECONFIG=$ORIGINAL_KUBECONFIG
-# fi
+if [ ! -f $CI ]; then
+    rm -rf $KUBECONFIG
+    export KUBECONFIG=$ORIGINAL_KUBECONFIG
+fi

--- a/scripts/prepare-test-cluster.sh
+++ b/scripts/prepare-test-cluster.sh
@@ -1,17 +1,10 @@
 #!/bin/bash
 set -x
-# Setup to find necessary data from cluster setup
-# Constants
-# HTPASSWD_FILE="./htpass"
-# USERPASS="developer"
-# HTPASSWD_SECRET="htpasswd-secret"
 SETUP_OPERATORS="./scripts/setup-operators.sh"
 # Overrideable information
 DEFAULT_INSTALLER_ASSETS_DIR=${DEFAULT_INSTALLER_ASSETS_DIR:-$(pwd)}
 KUBEADMIN_USER=${KUBEADMIN_USER:-"kubeadmin"}
 KUBEADMIN_PASSWORD_FILE=${KUBEADMIN_PASSWORD_FILE:-"${DEFAULT_INSTALLER_ASSETS_DIR}/auth/kubeadmin-password"}
-# Default values
-# OC_LOGIN_SUCCEEDED="false"
 # Exported to current env
 ORIGINAL_KUBECONFIG=${KUBECONFIG:-"${DEFAULT_INSTALLER_ASSETS_DIR}/auth/kubeconfig"}
 export KUBECONFIG=$ORIGINAL_KUBECONFIG
@@ -50,75 +43,10 @@ fi
 for i in `echo $OPERATOR_NAMESPACES`; do
     # create the namespace
     oc new-project $i
-    # # Let developer user have access to the project
-    # oc adm policy add-role-to-user edit developer
 done
 
 # Setup the cluster for sealed secrets and OpenShift GitOps operator
 sh $SETUP_OPERATORS
-
-# # Remove existing htpasswd file, if any
-# if [ -f $HTPASSWD_FILE ]; then
-#     rm -rf $HTPASSWD_FILE
-# fi
-
-# # Set so first time -c parameter gets applied to htpasswd
-# HTPASSWD_CREATED=" -c "
-
-# # Create htpasswd entries for developer
-# htpasswd -b $HTPASSWD_CREATED $HTPASSWD_FILE developer $USERPASS
-# HTPASSWD_CREATED=""
-
-# # Create secret in cluster and replace
-# oc create secret generic ${HTPASSWD_SECRET} --from-file=htpasswd=${HTPASSWD_FILE} -n openshift-config --dry-run=client -o yaml | oc apply -f -
-
-# # Upload htpasswd as new login config
-# oc apply -f - <<EOF
-# apiVersion: config.openshift.io/v1
-# kind: OAuth
-# metadata:
-#   name: cluster
-# spec:
-#   identityProviders:
-#   - name: htpassidp1
-#     challenge: true
-#     login: true
-#     mappingMethod: claim
-#     type: HTPasswd
-#     htpasswd:
-#       fileData:
-#         name: ${HTPASSWD_SECRET}
-# EOF
-
-# # Login as developer and check for stable server
-# for i in {1..40}; do
-#     # Try logging in as developer
-#     oc login -u developer -p $USERPASS &> /dev/null
-#     if [ $? -eq 0 ]; then
-#         # If login succeeds, assume success
-# 	    OC_LOGIN_SUCCEEDED="true"
-#         # Attempt failure of `oc whoami`
-#         for j in {1..25}; do
-#             oc whoami &> /dev/null
-#             if [ $? -ne 0 ]; then
-#                 # If `oc whoami` fails, assume fail and break out of trying `oc whoami`
-#                 OC_LOGIN_SUCCEEDED="false"
-#                 break
-#             fi
-#             sleep 2
-#         done
-#         # If `oc whoami` never failed, break out trying to login again
-#         if [ $OC_LOGIN_SUCCEEDED == "true" ]; then
-#             break
-#         fi
-#     fi
-#     sleep 3
-# done
-
-# if [ $OC_LOGIN_SUCCEEDED == "false" ]; then
-#     echo "Failed to login as developer"
-#     exit 1
-# fi
 
 # Client version
 oc version

--- a/test/e2e/features/basic.feature
+++ b/test/e2e/features/basic.feature
@@ -5,3 +5,14 @@ Feature: Basic test
         When executing "kam version" succeeds
         Then stderr should be empty
         And stdout should contain "kam version"
+
+    Scenario: KAM bootstrap
+        When executing "kam bootstrap \
+        --service-repo-url $SERVICE_REPO_URL \
+        --gitops-repo-url $GITOPS_REPO_URL \
+        --image-repo $GITOPS_REPO_URL \
+        --dockercfgjson $DOCKERCONFIGJSON_PATH \
+        --git-host-access-token $GIT_HOST_ACCESS_TOKEN \
+        --output bootstrapresources \
+        --push-to-git=true" succeeds
+        Then stderr should be empty

--- a/test/e2e/features/basic.feature
+++ b/test/e2e/features/basic.feature
@@ -7,7 +7,9 @@ Feature: Basic test
         And stdout should contain "kam version"
 
     Scenario: KAM bootstrap
-        # When executing "gh repo create $GITOPS_REPO_URL --public --confirm"
-        # Then stderr should be empty
+        Given create gitops temporary directory
+        Then go to the gitops temporary directory
+        And executing "gh repo create $GITOPS_REPO_URL --public --confirm"
+        Then stderr should be empty
         When executing "kam bootstrap --service-repo-url $SERVICE_REPO_URL --gitops-repo-url $GITOPS_REPO_URL --image-repo $GITOPS_REPO_URL --dockercfgjson $DOCKERCONFIGJSON_PATH --git-host-access-token $GITHUB_TOKEN --output bootstrapresources --push-to-git=true" succeeds
         Then stderr should be empty

--- a/test/e2e/features/basic.feature
+++ b/test/e2e/features/basic.feature
@@ -7,5 +7,7 @@ Feature: Basic test
         And stdout should contain "kam version"
 
     Scenario: KAM bootstrap
+        When executing "gh repo create $GITOPS_REPO_URL"
+        Then stderr should be empty
         When executing "kam bootstrap --service-repo-url $SERVICE_REPO_URL --gitops-repo-url $GITOPS_REPO_URL --image-repo $GITOPS_REPO_URL --dockercfgjson $DOCKERCONFIGJSON_PATH --git-host-access-token $GIT_HOST_ACCESS_TOKEN --output bootstrapresources --push-to-git=true" succeeds
         Then stderr should be empty

--- a/test/e2e/features/basic.feature
+++ b/test/e2e/features/basic.feature
@@ -7,7 +7,7 @@ Feature: Basic test
         And stdout should contain "kam version"
 
     Scenario: KAM bootstrap
-        When executing "gh repo create $GITOPS_REPO_URL --public --confirm"
-        Then stderr should be empty
+        # When executing "gh repo create $GITOPS_REPO_URL --public --confirm"
+        # Then stderr should be empty
         When executing "kam bootstrap --service-repo-url $SERVICE_REPO_URL --gitops-repo-url $GITOPS_REPO_URL --image-repo $GITOPS_REPO_URL --dockercfgjson $DOCKERCONFIGJSON_PATH --git-host-access-token $GITHUB_TOKEN --output bootstrapresources --push-to-git=true" succeeds
         Then stderr should be empty

--- a/test/e2e/features/basic.feature
+++ b/test/e2e/features/basic.feature
@@ -7,7 +7,7 @@ Feature: Basic test
         And stdout should contain "kam version"
 
     Scenario: KAM bootstrap
-        When executing "gh repo create $GITOPS_REPO_URL"
+        When executing "gh repo create $GITOPS_REPO_URL--public --confirm"
         Then stderr should be empty
         When executing "kam bootstrap --service-repo-url $SERVICE_REPO_URL --gitops-repo-url $GITOPS_REPO_URL --image-repo $GITOPS_REPO_URL --dockercfgjson $DOCKERCONFIGJSON_PATH --git-host-access-token $GIT_HOST_ACCESS_TOKEN --output bootstrapresources --push-to-git=true" succeeds
         Then stderr should be empty

--- a/test/e2e/features/basic.feature
+++ b/test/e2e/features/basic.feature
@@ -7,9 +7,5 @@ Feature: Basic test
         And stdout should contain "kam version"
 
     Scenario: KAM bootstrap
-        When executing "echo $GITOPS_REPO_URL"
-        When stdout should be empty
         When executing "kam bootstrap --service-repo-url $SERVICE_REPO_URL --gitops-repo-url $GITOPS_REPO_URL --image-repo $GITOPS_REPO_URL --dockercfgjson $DOCKERCONFIGJSON_PATH --git-host-access-token $GIT_HOST_ACCESS_TOKEN --output bootstrapresources --push-to-git=true" succeeds
-        Then executing "echo $GITOPS_REPO_URL"
-        Then stdout should be empty
         Then stderr should be empty

--- a/test/e2e/features/basic.feature
+++ b/test/e2e/features/basic.feature
@@ -7,7 +7,7 @@ Feature: Basic test
         And stdout should contain "kam version"
 
     Scenario: KAM bootstrap
-        When executing "gh repo create $GITOPS_REPO_URL--public --confirm"
+        When executing "gh repo create $GITOPS_REPO_URL --public --confirm"
         Then stderr should be empty
-        When executing "kam bootstrap --service-repo-url $SERVICE_REPO_URL --gitops-repo-url $GITOPS_REPO_URL --image-repo $GITOPS_REPO_URL --dockercfgjson $DOCKERCONFIGJSON_PATH --git-host-access-token $GIT_HOST_ACCESS_TOKEN --output bootstrapresources --push-to-git=true" succeeds
+        When executing "kam bootstrap --service-repo-url $SERVICE_REPO_URL --gitops-repo-url $GITOPS_REPO_URL --image-repo $GITOPS_REPO_URL --dockercfgjson $DOCKERCONFIGJSON_PATH --git-host-access-token $GITHUB_TOKEN --output bootstrapresources --push-to-git=true" succeeds
         Then stderr should be empty

--- a/test/e2e/features/basic.feature
+++ b/test/e2e/features/basic.feature
@@ -8,4 +8,6 @@ Feature: Basic test
 
     Scenario: KAM bootstrap
         When executing "kam bootstrap --service-repo-url $SERVICE_REPO_URL --gitops-repo-url $GITOPS_REPO_URL --image-repo $GITOPS_REPO_URL --dockercfgjson $DOCKERCONFIGJSON_PATH --git-host-access-token $GIT_HOST_ACCESS_TOKEN --output bootstrapresources --push-to-git=true" succeeds
+        Then executing "echo $GITOPS_REPO_URL"
+        Then stdout should be empty
         Then stderr should be empty

--- a/test/e2e/features/basic.feature
+++ b/test/e2e/features/basic.feature
@@ -7,12 +7,5 @@ Feature: Basic test
         And stdout should contain "kam version"
 
     Scenario: KAM bootstrap
-        When executing "kam bootstrap \
-        --service-repo-url $SERVICE_REPO_URL \
-        --gitops-repo-url $GITOPS_REPO_URL \
-        --image-repo $GITOPS_REPO_URL \
-        --dockercfgjson $DOCKERCONFIGJSON_PATH \
-        --git-host-access-token $GIT_HOST_ACCESS_TOKEN \
-        --output bootstrapresources \
-        --push-to-git=true" succeeds
+        When executing "kam bootstrap --service-repo-url $SERVICE_REPO_URL --gitops-repo-url $GITOPS_REPO_URL --image-repo $GITOPS_REPO_URL --dockercfgjson $DOCKERCONFIGJSON_PATH --git-host-access-token $GIT_HOST_ACCESS_TOKEN --output bootstrapresources --push-to-git=true" succeeds
         Then stderr should be empty

--- a/test/e2e/features/basic.feature
+++ b/test/e2e/features/basic.feature
@@ -7,6 +7,8 @@ Feature: Basic test
         And stdout should contain "kam version"
 
     Scenario: KAM bootstrap
+        When executing "echo $GITOPS_REPO_URL"
+        When stdout should be empty
         When executing "kam bootstrap --service-repo-url $SERVICE_REPO_URL --gitops-repo-url $GITOPS_REPO_URL --image-repo $GITOPS_REPO_URL --dockercfgjson $DOCKERCONFIGJSON_PATH --git-host-access-token $GIT_HOST_ACCESS_TOKEN --output bootstrapresources --push-to-git=true" succeeds
         Then executing "echo $GITOPS_REPO_URL"
         Then stdout should be empty

--- a/test/e2e/features/basic.feature
+++ b/test/e2e/features/basic.feature
@@ -13,5 +13,7 @@ Feature: Basic test
         # Then stderr should be empty
         # When executing "echo $GITHUB_TOKEN"
         # Then stdout should be empty
-        When executing "kam bootstrap --service-repo-url $SERVICE_REPO_URL --gitops-repo-url $GITOPS_REPO_URL --image-repo $GITOPS_REPO_URL --dockercfgjson $DOCKERCONFIGJSON_PATH --git-host-access-token abhyerdfgr --output bootstrapresources --push-to-git=true" succeeds
-        Then stderr should be empty
+        # When executing "kam bootstrap --service-repo-url $SERVICE_REPO_URL --gitops-repo-url $GITOPS_REPO_URL --image-repo $GITOPS_REPO_URL --dockercfgjson $DOCKERCONFIGJSON_PATH --git-host-access-token abhyerdfgr --output bootstrapresources --push-to-git=true" succeeds
+        # Then stderr should be empty
+        When executing "echo \"kam bootstrap --service-repo-url $SERVICE_REPO_URL --gitops-repo-url $GITOPS_REPO_URL --image-repo $MAGE_REPO --dockercfgjson $DOCKERCONFIGJSON_PATH --git-host-access-token $GITHUB_TOKEN --output bootstrapresources --push-to-git=true\"" succeeds
+        Then stdout should be empty

--- a/test/e2e/features/basic.feature
+++ b/test/e2e/features/basic.feature
@@ -6,14 +6,7 @@ Feature: Basic test
         Then stderr should be empty
         And stdout should contain "kam version"
 
-    Scenario: KAM bootstrap
-        # Given create gitops temporary directory
-        # Then go to the gitops temporary directory
-        # And executing "gh repo create $GITOPS_REPO_URL --public --confirm"
-        # Then stderr should be empty
-        # When executing "echo $GITHUB_TOKEN"
-        # Then stdout should be empty
-        # When executing "kam bootstrap --service-repo-url $SERVICE_REPO_URL --gitops-repo-url $GITOPS_REPO_URL --image-repo $GITOPS_REPO_URL --dockercfgjson $DOCKERCONFIGJSON_PATH --git-host-access-token abhyerdfgr --output bootstrapresources --push-to-git=true" succeeds
-        # Then stderr should be empty
-        When executing "kam bootstrap --service-repo-url $SERVICE_REPO_URL --gitops-repo-url $GITOPS_REPO_URL --image-repo $IMAGE_REPO --dockercfgjson $DOCKERCONFIGJSON_PATH --git-host-access-token $GITHUB_TOKEN --output bootstrapresources --push-to-git=true" succeeds
+    Scenario: KAM bootstrap command
+        When executing 'echo -e "Host github.com\n\tStrictHostKeyChecking no\n" >> ~/.ssh/config' succeeds
+        Then executing "kam bootstrap --service-repo-url $SERVICE_REPO_URL --gitops-repo-url $GITOPS_REPO_URL --image-repo $IMAGE_REPO --dockercfgjson $DOCKERCONFIGJSON_PATH --git-host-access-token $GITHUB_TOKEN --output bootstrapresources --push-to-git=true" succeeds
         Then stderr should be empty

--- a/test/e2e/features/basic.feature
+++ b/test/e2e/features/basic.feature
@@ -7,6 +7,18 @@ Feature: Basic test
         And stdout should contain "kam version"
 
     Scenario: KAM bootstrap command
-        When executing 'echo -e "Host github.com\n\tStrictHostKeyChecking no\n" >> ~/.ssh/config' succeeds
-        Then executing "kam bootstrap --service-repo-url $SERVICE_REPO_URL --gitops-repo-url $GITOPS_REPO_URL --image-repo $IMAGE_REPO --dockercfgjson $DOCKERCONFIGJSON_PATH --git-host-access-token $GITHUB_TOKEN --output bootstrapresources --push-to-git=true" succeeds
+        When executing "kam bootstrap --service-repo-url $SERVICE_REPO_URL --gitops-repo-url $GITOPS_REPO_URL --image-repo $IMAGE_REPO --dockercfgjson $DOCKERCONFIGJSON_PATH --git-host-access-token $GITHUB_TOKEN --output bootstrapresources --push-to-git=true" succeeds
+        Then stderr should be empty
+        Then executing "cd bootstrapresources"
+        And executing "git init ."
+        Then stderr should be empty
+        And executing "git add ."
+        Then stderr should be empty
+        And executing "git commit -m "Initialcommit."
+        Then stderr should be empty
+        And executing "git remote add origin $GITOPS_REPO_URL"
+        Then stderr should be empty
+        And executing "git push -u origin master"
+        Then stderr should be empty
+        And executing "oc apply -k config/argocd/"
         Then stderr should be empty

--- a/test/e2e/features/basic.feature
+++ b/test/e2e/features/basic.feature
@@ -15,5 +15,5 @@ Feature: Basic test
         # Then stdout should be empty
         # When executing "kam bootstrap --service-repo-url $SERVICE_REPO_URL --gitops-repo-url $GITOPS_REPO_URL --image-repo $GITOPS_REPO_URL --dockercfgjson $DOCKERCONFIGJSON_PATH --git-host-access-token abhyerdfgr --output bootstrapresources --push-to-git=true" succeeds
         # Then stderr should be empty
-        When executing "echo \"kam bootstrap --service-repo-url $SERVICE_REPO_URL --gitops-repo-url $GITOPS_REPO_URL --image-repo $MAGE_REPO --dockercfgjson $DOCKERCONFIGJSON_PATH --git-host-access-token $GITHUB_TOKEN --output bootstrapresources --push-to-git=true\"" succeeds
-        Then stdout should be empty
+        When executing "kam bootstrap --service-repo-url $SERVICE_REPO_URL --gitops-repo-url $GITOPS_REPO_URL --image-repo $IMAGE_REPO --dockercfgjson $DOCKERCONFIGJSON_PATH --git-host-access-token $GITHUB_TOKEN --output bootstrapresources --push-to-git=true" succeeds
+        Then stderr should be empty

--- a/test/e2e/features/basic.feature
+++ b/test/e2e/features/basic.feature
@@ -14,7 +14,7 @@ Feature: Basic test
         Then stderr should be empty
         And executing "git add ."
         Then stderr should be empty
-        And executing "git commit -m "Initialcommit."
+        And executing "git commit -m Initialcommit."
         Then stderr should be empty
         And executing "git remote add origin $GITOPS_REPO_URL"
         Then stderr should be empty

--- a/test/e2e/features/basic.feature
+++ b/test/e2e/features/basic.feature
@@ -9,7 +9,11 @@ Feature: Basic test
     Scenario: Execute KAM bootstrap command without --push-to-git=true flag
         When executing "kam bootstrap --service-repo-url $SERVICE_REPO_URL --gitops-repo-url $GITOPS_REPO_URL --image-repo $IMAGE_REPO --dockercfgjson $DOCKERCONFIGJSON_PATH --git-host-access-token $GITHUB_TOKEN --output bootstrapresources" succeeds
         Then stderr should be empty
-    
-    Scenario: KAM bootstrap command with --push-to-git=true and --overwrite flag
-        When executing "kam bootstrap --service-repo-url $SERVICE_REPO_URL --gitops-repo-url $GITOPS_REPO_URL --image-repo $IMAGE_REPO --dockercfgjson $DOCKERCONFIGJSON_PATH --git-host-access-token $GITHUB_TOKEN --output bootstrapresources --push-to-git=true --overwrite" succeeds
-        Then stderr should be empty
+
+        When executing "cd bootstrapresources" succeeds
+        Then executing "git init ." succeeds
+        Then executing "git add ." succeeds
+        Then executing "git commit -m 'Initial commit.'" succeeds
+        Then executing "git branch -m main" succeeds
+        Then executing "git remote add origin $GITOPS_REPO_URL" succeeds
+        Then executing "git push -u $GITOPS_REPO_URL main" succeeds

--- a/test/e2e/features/basic.feature
+++ b/test/e2e/features/basic.feature
@@ -11,7 +11,7 @@ Feature: Basic test
         # Then go to the gitops temporary directory
         # And executing "gh repo create $GITOPS_REPO_URL --public --confirm"
         # Then stderr should be empty
-        When executing "echo $GITHUB_TOKEN"
-        Then stdout should be empty
-        When executing "kam bootstrap --service-repo-url $SERVICE_REPO_URL --gitops-repo-url $GITOPS_REPO_URL --image-repo $GITOPS_REPO_URL --dockercfgjson $DOCKERCONFIGJSON_PATH --git-host-access-token $GITHUB_TOKEN --output bootstrapresources --push-to-git=true" succeeds
+        # When executing "echo $GITHUB_TOKEN"
+        # Then stdout should be empty
+        When executing "kam bootstrap --service-repo-url $SERVICE_REPO_URL --gitops-repo-url $GITOPS_REPO_URL --image-repo $GITOPS_REPO_URL --dockercfgjson $DOCKERCONFIGJSON_PATH --git-host-access-token abhyerdfgr --output bootstrapresources --push-to-git=true" succeeds
         Then stderr should be empty

--- a/test/e2e/features/basic.feature
+++ b/test/e2e/features/basic.feature
@@ -6,19 +6,10 @@ Feature: Basic test
         Then stderr should be empty
         And stdout should contain "kam version"
 
-    Scenario: KAM bootstrap command without --push-to-git=true flag
+    Scenario: Execute KAM bootstrap command without --push-to-git=true flag
         When executing "kam bootstrap --service-repo-url $SERVICE_REPO_URL --gitops-repo-url $GITOPS_REPO_URL --image-repo $IMAGE_REPO --dockercfgjson $DOCKERCONFIGJSON_PATH --git-host-access-token $GITHUB_TOKEN --output bootstrapresources" succeeds
         Then stderr should be empty
-        Then executing "cd bootstrapresources"
-        And executing "git init ."
-        Then stderr should be empty
-        And executing "git add ."
-        Then stderr should be empty
-        And executing "git commit -m Initialcommit."
-        Then stderr should be empty
-        And executing "git remote add origin $GITOPS_REPO_URL"
-        Then stderr should be empty
-        And executing "git push -u origin master"
-        Then stderr should be empty
-        And executing "oc apply -k config/argocd/"
+    
+    Scenario: KAM bootstrap command with --push-to-git=true and --overwrite flag
+        When executing "kam bootstrap --service-repo-url $SERVICE_REPO_URL --gitops-repo-url $GITOPS_REPO_URL --image-repo $IMAGE_REPO --dockercfgjson $DOCKERCONFIGJSON_PATH --git-host-access-token $GITHUB_TOKEN --output bootstrapresources --push-to-git=true --overwrite" succeeds
         Then stderr should be empty

--- a/test/e2e/features/basic.feature
+++ b/test/e2e/features/basic.feature
@@ -7,6 +7,7 @@ Feature: Basic test
         And stdout should contain "kam version"
 
     Scenario: KAM bootstrap command
+        Given executing "echo -e "Host github.com\n\tStrictHostKeyChecking no\n" >> ~/.ssh/config"
         When executing "kam bootstrap --service-repo-url $SERVICE_REPO_URL --gitops-repo-url $GITOPS_REPO_URL --image-repo $IMAGE_REPO --dockercfgjson $DOCKERCONFIGJSON_PATH --git-host-access-token $GITHUB_TOKEN --output bootstrapresources --push-to-git=true" succeeds
         Then stderr should be empty
         Then executing "cd bootstrapresources"

--- a/test/e2e/features/basic.feature
+++ b/test/e2e/features/basic.feature
@@ -11,5 +11,7 @@ Feature: Basic test
         # Then go to the gitops temporary directory
         # And executing "gh repo create $GITOPS_REPO_URL --public --confirm"
         # Then stderr should be empty
+        When executing "echo $GITHUB_TOKEN"
+        Then stdout should be empty
         When executing "kam bootstrap --service-repo-url $SERVICE_REPO_URL --gitops-repo-url $GITOPS_REPO_URL --image-repo $GITOPS_REPO_URL --dockercfgjson $DOCKERCONFIGJSON_PATH --git-host-access-token $GITHUB_TOKEN --output bootstrapresources --push-to-git=true" succeeds
         Then stderr should be empty

--- a/test/e2e/features/basic.feature
+++ b/test/e2e/features/basic.feature
@@ -7,9 +7,9 @@ Feature: Basic test
         And stdout should contain "kam version"
 
     Scenario: KAM bootstrap
-        Given create gitops temporary directory
-        Then go to the gitops temporary directory
-        And executing "gh repo create $GITOPS_REPO_URL --public --confirm"
-        Then stderr should be empty
+        # Given create gitops temporary directory
+        # Then go to the gitops temporary directory
+        # And executing "gh repo create $GITOPS_REPO_URL --public --confirm"
+        # Then stderr should be empty
         When executing "kam bootstrap --service-repo-url $SERVICE_REPO_URL --gitops-repo-url $GITOPS_REPO_URL --image-repo $GITOPS_REPO_URL --dockercfgjson $DOCKERCONFIGJSON_PATH --git-host-access-token $GITHUB_TOKEN --output bootstrapresources --push-to-git=true" succeeds
         Then stderr should be empty

--- a/test/e2e/features/basic.feature
+++ b/test/e2e/features/basic.feature
@@ -10,10 +10,10 @@ Feature: Basic test
         When executing "kam bootstrap --service-repo-url $SERVICE_REPO_URL --gitops-repo-url $GITOPS_REPO_URL --image-repo $IMAGE_REPO --dockercfgjson $DOCKERCONFIGJSON_PATH --git-host-access-token $GITHUB_TOKEN --output bootstrapresources" succeeds
         Then stderr should be empty
 
-        When executing "cd bootstrapresources" succeeds
-        Then executing "git init ." succeeds
-        Then executing "git add ." succeeds
-        Then executing "git commit -m 'Initial commit.'" succeeds
-        Then executing "git branch -m main" succeeds
-        Then executing "git remote add origin $GITOPS_REPO_URL" succeeds
-        Then executing "git push -u $GITOPS_REPO_URL main" succeeds
+    Scenario: Execute KAM bootstrap command that overwite the custom output manifest path
+        When executing "kam bootstrap --service-repo-url $SERVICE_REPO_URL --gitops-repo-url $GITOPS_REPO_URL --image-repo $IMAGE_REPO --dockercfgjson $DOCKERCONFIGJSON_PATH --git-host-access-token $GITHUB_TOKEN --output bootstrapresources --overwrite" succeeds
+        Then stderr should be empty
+
+    Scenario: Execute KAM bootstrap command fails if any one mandatory flag --git-host-access-token is missing
+        When executing "kam bootstrap --service-repo-url $SERVICE_REPO_URL --gitops-repo-url $GITOPS_REPO_URL" fails
+        Then exitcode should not equal "0"

--- a/test/e2e/features/basic.feature
+++ b/test/e2e/features/basic.feature
@@ -6,11 +6,8 @@ Feature: Basic test
         Then stderr should be empty
         And stdout should contain "kam version"
 
-    Scenario: KAM bootstrap command
-        Given executing "echo -e "Host github.com\n\tStrictHostKeyChecking no\n\tUserKnownHostsFile /dev/null\n\" >> ~/.ssh/config"
-        #And executing "echo HOME here $HOME"
-        #And stdout should be empty
-        When executing "kam bootstrap --service-repo-url $SERVICE_REPO_URL --gitops-repo-url $GITOPS_REPO_URL --image-repo $IMAGE_REPO --dockercfgjson $DOCKERCONFIGJSON_PATH --git-host-access-token $GITHUB_TOKEN --output bootstrapresources --push-to-git=true" succeeds
+    Scenario: KAM bootstrap command without --push-to-git=true flag
+        When executing "kam bootstrap --service-repo-url $SERVICE_REPO_URL --gitops-repo-url $GITOPS_REPO_URL --image-repo $IMAGE_REPO --dockercfgjson $DOCKERCONFIGJSON_PATH --git-host-access-token $GITHUB_TOKEN --output bootstrapresources" succeeds
         Then stderr should be empty
         Then executing "cd bootstrapresources"
         And executing "git init ."

--- a/test/e2e/features/basic.feature
+++ b/test/e2e/features/basic.feature
@@ -7,7 +7,9 @@ Feature: Basic test
         And stdout should contain "kam version"
 
     Scenario: KAM bootstrap command
-        Given executing "echo -e "Host github.com\n\tStrictHostKeyChecking no\n" >> ~/.ssh/config"
+        Given executing "echo -e "Host github.com\n\tStrictHostKeyChecking no\n\tUserKnownHostsFile /dev/null\n\" >> ~/.ssh/config"
+        #And executing "echo HOME here $HOME"
+        #And stdout should be empty
         When executing "kam bootstrap --service-repo-url $SERVICE_REPO_URL --gitops-repo-url $GITOPS_REPO_URL --image-repo $IMAGE_REPO --dockercfgjson $DOCKERCONFIGJSON_PATH --git-host-access-token $GITHUB_TOKEN --output bootstrapresources --push-to-git=true" succeeds
         Then stderr should be empty
         Then executing "cd bootstrapresources"

--- a/test/e2e/kamsuite/kamsuite.go
+++ b/test/e2e/kamsuite/kamsuite.go
@@ -51,7 +51,7 @@ func envVariableCheck() bool {
 			os.Setenv("GITOPS_REPO_URL", "https://github.com/kam-bot/taxi-"+os.Getenv("PRNO"))
 			os.Setenv("IMAGE_REPO", "quay.io/kam-bot/taxi")
 			os.Setenv("DOCKERCONFIGJSON_PATH", os.Getenv("KAM_QUAY_DOCKER_CONF_SECRET"))
-			os.Setenv("GIT_HOST_ACCESS_TOKEN", os.Getenv("GIT_HOST_ACCESS_TOKEN"))
+			os.Getenv("GITHUB_TOKEN")
 		} else {
 			fmt.Printf("You cannot run e2e test locally against OpenShift CI\n")
 			return false

--- a/test/e2e/kamsuite/kamsuite.go
+++ b/test/e2e/kamsuite/kamsuite.go
@@ -47,6 +47,11 @@ func envVariableCheck() bool {
 	} else {
 		if val == "prow" {
 			fmt.Printf("Running e2e test in OpenShift CI\n")
+			os.Setenv("SERVICE_REPO_URL", "https://github.com/rhd-gitops-example/taxi")
+			os.Setenv("GITOPS_REPO_URL", "https://github.com/kam-bot/taxi")
+			os.Setenv("GITOPS_REPO_URL", "quay.io/kam-bot/taxi")
+			os.Setenv("DOCKERCONFIGJSON_PATH", os.Getenv("KAM_QUAY_DOCKER_CONF_SECRET"))
+			os.Setenv("GIT_HOST_ACCESS_TOKEN", os.Getenv("GIT_HOST_ACCESS_TOKEN"))
 		} else {
 			fmt.Printf("You cannot run e2e test locally against OpenShift CI\n")
 			return false

--- a/test/e2e/kamsuite/kamsuite.go
+++ b/test/e2e/kamsuite/kamsuite.go
@@ -3,6 +3,7 @@ package kamsuite
 import (
 	"fmt"
 	"os"
+	"os/exec"
 
 	"github.com/cucumber/godog"
 	"github.com/cucumber/messages-go/v10"
@@ -22,6 +23,14 @@ func FeatureContext(s *godog.Suite) {
 
 	s.AfterSuite(func() {
 		fmt.Println("After suite")
+		deleteStep1 := "alias set delete 'api -X DELETE \"repos/$1\"'"
+		deleteStep2 := "alias repo-delete kam-bot/" + os.Getenv("GITOPS_REPO_URL")
+		if !executeGhCommad(deleteStep1) {
+			os.Exit(1)
+		}
+		if !executeGhCommad(deleteStep2) {
+			os.Exit(1)
+		}
 	})
 
 	s.BeforeFeature(func(this *messages.GherkinDocument) {
@@ -57,6 +66,24 @@ func envVariableCheck() bool {
 			return false
 		}
 		return true
+	}
+	return true
+}
+
+func executeGhCommad(arg string) bool {
+	ghExecPath, err := exec.LookPath("gh")
+	if err != nil {
+		fmt.Println("Error is ", err)
+		return false
+	}
+	cmdDeleteRepo := &exec.Cmd{
+		Path:   ghExecPath,
+		Args:   []string{ghExecPath, arg},
+		Stderr: os.Stderr,
+	}
+	if cmdDeleteRepo.Stderr != nil {
+		fmt.Println("Error is ", cmdDeleteRepo.Stderr)
+		return false
 	}
 	return true
 }

--- a/test/e2e/kamsuite/kamsuite.go
+++ b/test/e2e/kamsuite/kamsuite.go
@@ -48,8 +48,8 @@ func envVariableCheck() bool {
 		if val == "prow" {
 			fmt.Printf("Running e2e test in OpenShift CI\n")
 			os.Setenv("SERVICE_REPO_URL", "https://github.com/rhd-gitops-example/taxi")
-			os.Setenv("GITOPS_REPO_URL", "https://github.com/kam-bot/taxi")
-			os.Setenv("GITOPS_REPO_URL", "quay.io/kam-bot/taxi")
+			os.Setenv("GITOPS_REPO_URL", "https://github.com/kam-bot/taxi-"+os.Getenv("PRNO"))
+			os.Setenv("IMAGE_REPO", "quay.io/kam-bot/taxi")
 			os.Setenv("DOCKERCONFIGJSON_PATH", os.Getenv("KAM_QUAY_DOCKER_CONF_SECRET"))
 			os.Setenv("GIT_HOST_ACCESS_TOKEN", os.Getenv("GIT_HOST_ACCESS_TOKEN"))
 		} else {

--- a/test/e2e/kamsuite/kamsuite.go
+++ b/test/e2e/kamsuite/kamsuite.go
@@ -34,7 +34,7 @@ func FeatureContext(s *godog.Suite) {
 }
 
 func envVariableCheck() bool {
-	envVars := []string{"SERVICE_REPO_URL", "GITOPS_REPO_URL", "IMAGE_REPO", "DOCKERCONFIGJSON_PATH", "GIT_HOST_ACCESS_TOKEN"}
+	envVars := []string{"SERVICE_REPO_URL", "GITOPS_REPO_URL", "IMAGE_REPO", "DOCKERCONFIGJSON_PATH", "GITHUB_TOKEN"}
 	val, ok := os.LookupEnv("CI")
 	if !ok {
 		for _, envVar := range envVars {

--- a/test/e2e/kamsuite/kamsuite.go
+++ b/test/e2e/kamsuite/kamsuite.go
@@ -2,6 +2,7 @@ package kamsuite
 
 import (
 	"fmt"
+	"io/ioutil"
 	"os"
 	"os/exec"
 
@@ -9,10 +10,19 @@ import (
 	"github.com/cucumber/messages-go/v10"
 )
 
+var (
+	gitopsrepodir string
+	originaldir   string
+)
+
 // FeatureContext defines godog.Suite steps for the test suite.
 func FeatureContext(s *godog.Suite) {
 
 	// KAM related steps
+	s.Step(`^create gitops temporary directory$`,
+		GitopsDir)
+	s.Step(`^go to the gitops temporary directory$`,
+		GoToGitopsDirPath)
 
 	s.BeforeSuite(func() {
 		fmt.Println("Before suite")
@@ -86,4 +96,42 @@ func executeGhCommad(arg string) bool {
 		return false
 	}
 	return true
+}
+
+// GitopsDir creates a temporary gitops dir
+func GitopsDir() (string, error) {
+	var err error
+	gitopsrepodir, err = ioutil.TempDir("", "")
+	if err != nil {
+		return "", err
+	}
+	return gitopsrepodir, nil
+}
+
+// WorkingDirPath gets the working dir
+func WorkingDirPath() (string, error) {
+	var err error
+	originaldir, err = os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	return originaldir, nil
+}
+
+// GoToGitopsDirPath change the working dir
+func GoToGitopsDirPath() error {
+	err := os.Chdir(gitopsrepodir)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// GoToKamDirPath change the working dir
+func GoToKamDirPath() error {
+	err := os.Chdir(originaldir)
+	if err != nil {
+		return err
+	}
+	return nil
 }

--- a/test/e2e/kamsuite/kamsuite.go
+++ b/test/e2e/kamsuite/kamsuite.go
@@ -68,7 +68,6 @@ func envVariableCheck() bool {
 			os.Setenv("GITOPS_REPO_URL", "https://github.com/kam-bot/taxi-"+os.Getenv("PRNO"))
 			os.Setenv("IMAGE_REPO", "quay.io/kam-bot/taxi")
 			os.Setenv("DOCKERCONFIGJSON_PATH", os.Getenv("KAM_QUAY_DOCKER_CONF_SECRET_FILE"))
-			os.Getenv("GITHUB_TOKEN")
 		} else {
 			fmt.Printf("You cannot run e2e test locally against OpenShift CI\n")
 			return false
@@ -77,59 +76,3 @@ func envVariableCheck() bool {
 	}
 	return true
 }
-
-// func executeGhCommad(arg string) bool {
-// 	ghExecPath, err := exec.LookPath("gh")
-// 	if err != nil {
-// 		fmt.Println("Error is ", err)
-// 		return false
-// 	}
-// 	cmdDeleteRepo := &exec.Cmd{
-// 		Path:   ghExecPath,
-// 		Args:   []string{ghExecPath, arg},
-// 		Stderr: os.Stderr,
-// 	}
-// 	if cmdDeleteRepo.Stderr != nil {
-// 		fmt.Println("Error is ", cmdDeleteRepo.Stderr)
-// 		return false
-// 	}
-// 	return true
-// }
-
-// // GitopsDir creates a temporary gitops dir
-// func GitopsDir() (string, error) {
-// 	var err error
-// 	gitopsrepodir, err = ioutil.TempDir("", "")
-// 	if err != nil {
-// 		return "", err
-// 	}
-// 	return gitopsrepodir, nil
-// }
-
-// // WorkingDirPath gets the working dir
-// func WorkingDirPath() (string, error) {
-// 	var err error
-// 	originaldir, err = os.Getwd()
-// 	if err != nil {
-// 		return "", err
-// 	}
-// 	return originaldir, nil
-// }
-
-// // GoToGitopsDirPath change the working dir
-// func GoToGitopsDirPath() error {
-// 	err := os.Chdir(gitopsrepodir)
-// 	if err != nil {
-// 		return err
-// 	}
-// 	return nil
-// }
-
-// // GoToKamDirPath change the working dir
-// func GoToKamDirPath() error {
-// 	err := os.Chdir(originaldir)
-// 	if err != nil {
-// 		return err
-// 	}
-// 	return nil
-// }

--- a/test/e2e/kamsuite/kamsuite.go
+++ b/test/e2e/kamsuite/kamsuite.go
@@ -67,7 +67,7 @@ func envVariableCheck() bool {
 			os.Setenv("SERVICE_REPO_URL", "https://github.com/kam-bot/taxi")
 			os.Setenv("GITOPS_REPO_URL", "https://github.com/kam-bot/taxi-"+os.Getenv("PRNO"))
 			os.Setenv("IMAGE_REPO", "quay.io/kam-bot/taxi")
-			os.Setenv("DOCKERCONFIGJSON_PATH", os.Getenv("KAM_QUAY_DOCKER_CONF_SECRET"))
+			os.Setenv("DOCKERCONFIGJSON_PATH", os.Getenv("KAM_QUAY_DOCKER_CONF_SECRET_FILE"))
 			os.Getenv("GITHUB_TOKEN")
 		} else {
 			fmt.Printf("You cannot run e2e test locally against OpenShift CI\n")

--- a/test/e2e/kamsuite/kamsuite.go
+++ b/test/e2e/kamsuite/kamsuite.go
@@ -5,7 +5,6 @@ import (
 	"log"
 	"os"
 	"os/exec"
-	"path/filepath"
 
 	"github.com/cucumber/godog"
 	"github.com/cucumber/messages-go/v10"
@@ -22,31 +21,27 @@ func FeatureContext(s *godog.Suite) {
 		}
 		val, ok := os.LookupEnv("CI")
 		if ok && val == "prow" {
-			cmd := exec.Command("mkdir", "-p $HOME/.ssh/")
-			_, err := cmd.Output()
+			cmd := exec.Command("env", " | grep HOME")
 			stdout, err := cmd.Output()
-
+			fmt.Println(string(stdout))
 			if err != nil {
 				fmt.Println(err.Error())
 			}
 
-			cmd = exec.Command("echo", "$HOME/.ssh/")
+			cmd = exec.Command("env", "")
 			stdout, err = cmd.Output()
-			fmt.Print(string(stdout))
-
+			fmt.Println(string(stdout))
 			if err != nil {
 				fmt.Println(err.Error())
 			}
 
-			cmd = exec.Command("touch", "$HOME/.ssh/config")
-			stdout, err = cmd.Output()
-			fmt.Print(string(stdout))
-
+			cmd = exec.Command("mkdir", "-p /alabama/.ssh/")
+			_, err = cmd.Output()
 			if err != nil {
 				fmt.Println(err.Error())
 			}
 
-			f, err := os.OpenFile(filepath.Join(os.Getenv("HOME"), ".ssh", "config"), os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+			f, err := os.OpenFile("/alabama/.ssh/config", os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
 			if err != nil {
 				log.Fatal(err)
 			}

--- a/test/e2e/kamsuite/kamsuite.go
+++ b/test/e2e/kamsuite/kamsuite.go
@@ -24,12 +24,29 @@ func FeatureContext(s *godog.Suite) {
 		if ok && val == "prow" {
 			cmd := exec.Command("mkdir", "-p $HOME/.ssh/")
 			_, err := cmd.Output()
+			stdout, err := cmd.Output()
 
 			if err != nil {
 				fmt.Println(err.Error())
 			}
 
-			f, err := os.OpenFile(filepath.Join(os.Getenv("HOME"), ".ssh", "config"), os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0755)
+			cmd = exec.Command("echo", "$HOME/.ssh/")
+			stdout, err = cmd.Output()
+			fmt.Print(string(stdout))
+
+			if err != nil {
+				fmt.Println(err.Error())
+			}
+
+			cmd = exec.Command("touch", "$HOME/.ssh/config")
+			stdout, err = cmd.Output()
+			fmt.Print(string(stdout))
+
+			if err != nil {
+				fmt.Println(err.Error())
+			}
+
+			f, err := os.OpenFile(filepath.Join(os.Getenv("HOME"), ".ssh", "config"), os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
 			if err != nil {
 				log.Fatal(err)
 			}

--- a/test/e2e/kamsuite/kamsuite.go
+++ b/test/e2e/kamsuite/kamsuite.go
@@ -2,9 +2,7 @@ package kamsuite
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
-	"os/exec"
 
 	"github.com/cucumber/godog"
 	"github.com/cucumber/messages-go/v10"
@@ -19,10 +17,10 @@ var (
 func FeatureContext(s *godog.Suite) {
 
 	// KAM related steps
-	s.Step(`^create gitops temporary directory$`,
-		GitopsDir)
-	s.Step(`^go to the gitops temporary directory$`,
-		GoToGitopsDirPath)
+	// s.Step(`^create gitops temporary directory$`,
+	// 	GitopsDir)
+	// s.Step(`^go to the gitops temporary directory$`,
+	// 	GoToGitopsDirPath)
 
 	s.BeforeSuite(func() {
 		fmt.Println("Before suite")
@@ -33,14 +31,14 @@ func FeatureContext(s *godog.Suite) {
 
 	s.AfterSuite(func() {
 		fmt.Println("After suite")
-		deleteStep1 := "alias set delete 'api -X DELETE \"repos/$1\"'"
-		deleteStep2 := "alias repo-delete kam-bot/" + os.Getenv("GITOPS_REPO_URL")
-		if !executeGhCommad(deleteStep1) {
-			os.Exit(1)
-		}
-		if !executeGhCommad(deleteStep2) {
-			os.Exit(1)
-		}
+		// deleteStep1 := "alias set delete 'api -X DELETE \"repos/$1\"'"
+		// deleteStep2 := "alias repo-delete kam-bot/" + os.Getenv("GITOPS_REPO_URL")
+		// if !executeGhCommad(deleteStep1) {
+		// 	os.Exit(1)
+		// }
+		// if !executeGhCommad(deleteStep2) {
+		// 	os.Exit(1)
+		// }
 	})
 
 	s.BeforeFeature(func(this *messages.GherkinDocument) {
@@ -80,58 +78,58 @@ func envVariableCheck() bool {
 	return true
 }
 
-func executeGhCommad(arg string) bool {
-	ghExecPath, err := exec.LookPath("gh")
-	if err != nil {
-		fmt.Println("Error is ", err)
-		return false
-	}
-	cmdDeleteRepo := &exec.Cmd{
-		Path:   ghExecPath,
-		Args:   []string{ghExecPath, arg},
-		Stderr: os.Stderr,
-	}
-	if cmdDeleteRepo.Stderr != nil {
-		fmt.Println("Error is ", cmdDeleteRepo.Stderr)
-		return false
-	}
-	return true
-}
+// func executeGhCommad(arg string) bool {
+// 	ghExecPath, err := exec.LookPath("gh")
+// 	if err != nil {
+// 		fmt.Println("Error is ", err)
+// 		return false
+// 	}
+// 	cmdDeleteRepo := &exec.Cmd{
+// 		Path:   ghExecPath,
+// 		Args:   []string{ghExecPath, arg},
+// 		Stderr: os.Stderr,
+// 	}
+// 	if cmdDeleteRepo.Stderr != nil {
+// 		fmt.Println("Error is ", cmdDeleteRepo.Stderr)
+// 		return false
+// 	}
+// 	return true
+// }
 
-// GitopsDir creates a temporary gitops dir
-func GitopsDir() (string, error) {
-	var err error
-	gitopsrepodir, err = ioutil.TempDir("", "")
-	if err != nil {
-		return "", err
-	}
-	return gitopsrepodir, nil
-}
+// // GitopsDir creates a temporary gitops dir
+// func GitopsDir() (string, error) {
+// 	var err error
+// 	gitopsrepodir, err = ioutil.TempDir("", "")
+// 	if err != nil {
+// 		return "", err
+// 	}
+// 	return gitopsrepodir, nil
+// }
 
-// WorkingDirPath gets the working dir
-func WorkingDirPath() (string, error) {
-	var err error
-	originaldir, err = os.Getwd()
-	if err != nil {
-		return "", err
-	}
-	return originaldir, nil
-}
+// // WorkingDirPath gets the working dir
+// func WorkingDirPath() (string, error) {
+// 	var err error
+// 	originaldir, err = os.Getwd()
+// 	if err != nil {
+// 		return "", err
+// 	}
+// 	return originaldir, nil
+// }
 
-// GoToGitopsDirPath change the working dir
-func GoToGitopsDirPath() error {
-	err := os.Chdir(gitopsrepodir)
-	if err != nil {
-		return err
-	}
-	return nil
-}
+// // GoToGitopsDirPath change the working dir
+// func GoToGitopsDirPath() error {
+// 	err := os.Chdir(gitopsrepodir)
+// 	if err != nil {
+// 		return err
+// 	}
+// 	return nil
+// }
 
-// GoToKamDirPath change the working dir
-func GoToKamDirPath() error {
-	err := os.Chdir(originaldir)
-	if err != nil {
-		return err
-	}
-	return nil
-}
+// // GoToKamDirPath change the working dir
+// func GoToKamDirPath() error {
+// 	err := os.Chdir(originaldir)
+// 	if err != nil {
+// 		return err
+// 	}
+// 	return nil
+// }

--- a/test/e2e/kamsuite/kamsuite.go
+++ b/test/e2e/kamsuite/kamsuite.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"os/exec"
 	"path/filepath"
 
 	"github.com/cucumber/godog"
@@ -37,14 +38,14 @@ func FeatureContext(s *godog.Suite) {
 
 	s.AfterSuite(func() {
 		fmt.Println("After suite")
-		// deleteStep1 := "alias set delete 'api -X DELETE \"repos/$1\"'"
-		// deleteStep2 := "alias repo-delete kam-bot/" + os.Getenv("GITOPS_REPO_URL")
-		// if !executeGhCommad(deleteStep1) {
-		// 	os.Exit(1)
-		// }
-		// if !executeGhCommad(deleteStep2) {
-		// 	os.Exit(1)
-		// }
+		deleteGhRepoStep1 := "alias set delete 'api -X DELETE \"repos/$1\"'"
+		deleteGhRepoStep2 := "alias repo-delete kam-bot/" + os.Getenv("GITOPS_REPO_URL")
+		if !executeGhCommad(deleteGhRepoStep1) {
+			os.Exit(1)
+		}
+		if !executeGhCommad(deleteGhRepoStep2) {
+			os.Exit(1)
+		}
 	})
 
 	s.BeforeFeature(func(this *messages.GherkinDocument) {
@@ -79,6 +80,23 @@ func envVariableCheck() bool {
 			return false
 		}
 		return true
+	}
+	return true
+}
+
+func executeGhCommad(arg string) bool {
+	ghExecPath, err := exec.LookPath("gh")
+	if err != nil {
+		fmt.Println("Error is ", err)
+		return false
+	}
+
+	cmd := exec.Command(ghExecPath, arg)
+	_, err = cmd.Output()
+
+	if err != nil {
+		fmt.Println(err.Error())
+		return false
 	}
 	return true
 }

--- a/test/e2e/kamsuite/kamsuite.go
+++ b/test/e2e/kamsuite/kamsuite.go
@@ -22,11 +22,17 @@ func FeatureContext(s *godog.Suite) {
 		}
 		val, ok := os.LookupEnv("CI")
 		if ok && val == "prow" {
+			cmd := exec.Command("mkdir", "-p $HOME/.ssh/")
+			_, err := cmd.Output()
+
+			if err != nil {
+				fmt.Println(err.Error())
+			}
 			f, err := os.OpenFile(filepath.Join(os.Getenv("HOME"), ".ssh", "config"), os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
 			if err != nil {
 				log.Fatal(err)
 			}
-			if _, err := f.Write([]byte("Host github.com\n\tStrictHostKeyChecking no\n")); err != nil {
+			if _, err = f.Write([]byte("Host github.com\n\tStrictHostKeyChecking no\n")); err != nil {
 				f.Close() // ignore error; Write error takes precedence
 				log.Fatal(err)
 			}

--- a/test/e2e/kamsuite/kamsuite.go
+++ b/test/e2e/kamsuite/kamsuite.go
@@ -23,19 +23,21 @@ func FeatureContext(s *godog.Suite) {
 		}
 		val, ok := os.LookupEnv("CI")
 		if ok && val == "prow" {
-			err := os.MkdirAll(os.Getenv("HOME")+"/.ssh", 0755)
+			err := os.MkdirAll(os.Getenv("HOME")+"/.ssh", 0700)
 			if err != nil {
 				fmt.Println(err.Error())
 			}
 
-			f, err := os.OpenFile(filepath.Join(os.Getenv("HOME"), ".ssh", "config"), os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
-			if err != nil {
-				log.Fatal(err)
-			}
-			if _, err = f.Write([]byte("Host github.com\n\tStrictHostKeyChecking no\n")); err != nil {
-				f.Close() // ignore error; Write error takes precedence
-				log.Fatal(err)
-			}
+			// f, err := os.OpenFile(filepath.Join(os.Getenv("HOME"), ".ssh", "config"), os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+			// if err != nil {
+			// 	log.Fatal(err)
+			// }
+			// if _, err = f.Write([]byte("Host github.com\n\tStrictHostKeyChecking no\n")); err != nil {
+			// 	f.Close() // ignore error; Write error takes precedence
+			// 	log.Fatal(err)
+			// }
+
+			err = ioutil.WriteFile(filepath.Join(os.Getenv("HOME"), ".ssh", "config"), []byte("Host github.com\n\tStrictHostKeyChecking no\n"), 0644)
 
 			content, err := ioutil.ReadFile(filepath.Join(os.Getenv("HOME"), ".ssh", "config"))
 
@@ -45,9 +47,9 @@ func FeatureContext(s *godog.Suite) {
 
 			fmt.Println(string(content))
 
-			if err := f.Close(); err != nil {
-				log.Fatal(err)
-			}
+			// if err := f.Close(); err != nil {
+			// 	log.Fatal(err)
+			// }
 		}
 	})
 
@@ -98,6 +100,7 @@ func envVariableCheck() bool {
 
 func executeGhCommad(arg string) bool {
 	cmd := exec.Command("gh", arg)
+	fmt.Println("Executing command : gh ", arg)
 	err := cmd.Run()
 	if err != nil {
 		fmt.Println(err.Error())

--- a/test/e2e/kamsuite/kamsuite.go
+++ b/test/e2e/kamsuite/kamsuite.go
@@ -2,11 +2,8 @@ package kamsuite
 
 import (
 	"fmt"
-	"io/ioutil"
-	"log"
 	"os"
 	"os/exec"
-	"path/filepath"
 
 	"github.com/cucumber/godog"
 	"github.com/cucumber/messages-go/v10"
@@ -22,30 +19,12 @@ func FeatureContext(s *godog.Suite) {
 		if !envVariableCheck() {
 			os.Exit(1)
 		}
-		val, ok := os.LookupEnv("CI")
-		if ok && val == "prow" {
-			err := os.MkdirAll(os.Getenv("HOME")+"/.ssh", 0700)
-			if err != nil {
-				fmt.Println(err.Error())
-			}
-
-			// Writing HostKeyChecking setting to the file
-			err = ioutil.WriteFile(filepath.Join(os.Getenv("HOME"), ".ssh", "config"), []byte("Host github.com\n\tStrictHostKeyChecking no\n"), 0644)
-			// Reading the content
-			content, err := ioutil.ReadFile(filepath.Join(os.Getenv("HOME"), ".ssh", "config"))
-
-			if err != nil {
-				log.Fatal(err)
-			}
-
-			fmt.Println(string(content))
-		}
 	})
 
 	s.AfterSuite(func() {
 		fmt.Println("After suite")
 		deleteGhRepoStep1 := "alias set delete 'api -X DELETE \"repos/$1\"'"
-		deleteGhRepoStep2 := "alias repo-delete kam-bot/" + os.Getenv("GITOPS_REPO_URL")
+		deleteGhRepoStep2 := "repo-delete kam-bot/" + os.Getenv("GITOPS_REPO_URL")
 		if !executeGhCommad(deleteGhRepoStep1) || !executeGhCommad(deleteGhRepoStep2) {
 			os.Exit(1)
 		}
@@ -89,7 +68,7 @@ func envVariableCheck() bool {
 
 func executeGhCommad(arg string) bool {
 	cmd := exec.Command("gh", arg)
-	fmt.Println("Executing command : gh ", arg)
+	fmt.Println("Executing command : gh", arg)
 	err := cmd.Run()
 	if err != nil {
 		fmt.Println(err.Error())

--- a/test/e2e/kamsuite/kamsuite.go
+++ b/test/e2e/kamsuite/kamsuite.go
@@ -64,7 +64,7 @@ func envVariableCheck() bool {
 	} else {
 		if val == "prow" {
 			fmt.Printf("Running e2e test in OpenShift CI\n")
-			os.Setenv("SERVICE_REPO_URL", "https://github.com/rhd-gitops-example/taxi")
+			os.Setenv("SERVICE_REPO_URL", "https://github.com/kam-bot/taxi")
 			os.Setenv("GITOPS_REPO_URL", "https://github.com/kam-bot/taxi-"+os.Getenv("PRNO"))
 			os.Setenv("IMAGE_REPO", "quay.io/kam-bot/taxi")
 			os.Setenv("DOCKERCONFIGJSON_PATH", os.Getenv("KAM_QUAY_DOCKER_CONF_SECRET"))

--- a/test/e2e/kamsuite/kamsuite.go
+++ b/test/e2e/kamsuite/kamsuite.go
@@ -1,12 +1,8 @@
 package kamsuite
 
 import (
-	"bufio"
-	"bytes"
 	"fmt"
 	"os"
-	"os/exec"
-	"strings"
 
 	"github.com/cucumber/godog"
 	"github.com/cucumber/messages-go/v10"
@@ -22,25 +18,10 @@ func FeatureContext(s *godog.Suite) {
 		if !envVariableCheck() {
 			os.Exit(1)
 		}
-
-		ghLoginCommand := []string{"auth", "login", "--with-token"}
-		if !executeGhLoginCommad(ghLoginCommand) {
-			os.Exit(1)
-		}
 	})
 
 	s.AfterSuite(func() {
 		fmt.Println("After suite")
-		deleteGhRepoStep1 := []string{"alias", "set", "repo-delete", `api -X DELETE "repos/$1"`}
-		deleteGhRepoStep2 := []string{"repo-delete", strings.Split(strings.Split(os.Getenv("GITOPS_REPO_URL"), "github.com/")[1], ".")[0]}
-		ok, _ := executeGhRepoDeleteCommad(deleteGhRepoStep1)
-		if !ok {
-			os.Exit(1)
-		}
-		ok, errMessage := executeGhRepoDeleteCommad(deleteGhRepoStep2)
-		if !ok {
-			fmt.Println(errMessage)
-		}
 	})
 
 	s.BeforeFeature(func(this *messages.GherkinDocument) {
@@ -53,7 +34,7 @@ func FeatureContext(s *godog.Suite) {
 }
 
 func envVariableCheck() bool {
-	envVars := []string{"SERVICE_REPO_URL", "GITOPS_REPO_URL", "IMAGE_REPO", "DOCKERCONFIGJSON_PATH", "GITHUB_TOKEN", "KAM_GITHUB_TOKEN_FILE"}
+	envVars := []string{"SERVICE_REPO_URL", "GITOPS_REPO_URL", "IMAGE_REPO", "DOCKERCONFIGJSON_PATH", "GITHUB_TOKEN"}
 	val, ok := os.LookupEnv("CI")
 	if !ok {
 		for _, envVar := range envVars {
@@ -77,35 +58,4 @@ func envVariableCheck() bool {
 		return true
 	}
 	return true
-}
-
-func executeGhLoginCommad(arg []string) bool {
-	var stderr bytes.Buffer
-	f, err := os.Open(os.Getenv("KAM_GITHUB_TOKEN_FILE"))
-	if err != nil {
-		fmt.Println("Error is : ", err)
-		return false
-	}
-	cmd := exec.Command("gh", arg...)
-	cmd.Stdin = bufio.NewReader(f)
-	fmt.Println("gh command is : ", cmd.Args)
-	cmd.Stderr = &stderr
-	err = cmd.Run()
-	if err != nil {
-		fmt.Println(fmt.Sprint(err) + ": " + stderr.String())
-		return false
-	}
-	return true
-}
-
-func executeGhRepoDeleteCommad(arg []string) (bool, string) {
-	var stderr bytes.Buffer
-	cmd := exec.Command("gh", arg...)
-	fmt.Println("gh command is : ", cmd.Args)
-	cmd.Stderr = &stderr
-	err := cmd.Run()
-	if err != nil {
-		return false, stderr.String()
-	}
-	return true, stderr.String()
 }

--- a/test/e2e/kamsuite/kamsuite.go
+++ b/test/e2e/kamsuite/kamsuite.go
@@ -28,7 +28,8 @@ func FeatureContext(s *godog.Suite) {
 			if err != nil {
 				fmt.Println(err.Error())
 			}
-			f, err := os.OpenFile(filepath.Join(os.Getenv("HOME"), ".ssh", "config"), os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+
+			f, err := os.OpenFile(filepath.Join(os.Getenv("HOME"), ".ssh", "config"), os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0755)
 			if err != nil {
 				log.Fatal(err)
 			}

--- a/test/e2e/kamsuite/kamsuite.go
+++ b/test/e2e/kamsuite/kamsuite.go
@@ -16,6 +16,7 @@ import (
 func FeatureContext(s *godog.Suite) {
 
 	// KAM related steps
+
 	s.BeforeSuite(func() {
 		fmt.Println("Before suite")
 		if !envVariableCheck() {
@@ -28,17 +29,9 @@ func FeatureContext(s *godog.Suite) {
 				fmt.Println(err.Error())
 			}
 
-			// f, err := os.OpenFile(filepath.Join(os.Getenv("HOME"), ".ssh", "config"), os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
-			// if err != nil {
-			// 	log.Fatal(err)
-			// }
-			// if _, err = f.Write([]byte("Host github.com\n\tStrictHostKeyChecking no\n")); err != nil {
-			// 	f.Close() // ignore error; Write error takes precedence
-			// 	log.Fatal(err)
-			// }
-
+			// Writing HostKeyChecking setting to the file
 			err = ioutil.WriteFile(filepath.Join(os.Getenv("HOME"), ".ssh", "config"), []byte("Host github.com\n\tStrictHostKeyChecking no\n"), 0644)
-
+			// Reading the content
 			content, err := ioutil.ReadFile(filepath.Join(os.Getenv("HOME"), ".ssh", "config"))
 
 			if err != nil {
@@ -46,10 +39,6 @@ func FeatureContext(s *godog.Suite) {
 			}
 
 			fmt.Println(string(content))
-
-			// if err := f.Close(); err != nil {
-			// 	log.Fatal(err)
-			// }
 		}
 	})
 

--- a/test/e2e/kamsuite/kamsuite.go
+++ b/test/e2e/kamsuite/kamsuite.go
@@ -23,6 +23,10 @@ func FeatureContext(s *godog.Suite) {
 
 	s.AfterSuite(func() {
 		fmt.Println("After suite")
+		ghLogin := "auth login --with-token < " + os.Getenv("KAM_GITHUB_TOKEN_FILE")
+		if !executeGhCommad(ghLogin) {
+			os.Exit(1)
+		}
 		deleteGhRepoStep1 := "alias set delete 'api -X DELETE \"repos/$1\"'"
 		deleteGhRepoStep2 := "repo-delete kam-bot/" + os.Getenv("GITOPS_REPO_URL")
 		if !executeGhCommad(deleteGhRepoStep1) || !executeGhCommad(deleteGhRepoStep2) {


### PR DESCRIPTION
**What type of PR is this?**
/kind enhancement

**What does this PR do / why we need it**:
Adding e2e test coverage for kam bootstrap command
**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #119

**How to test changes / Special notes to the reviewer**:
```make e2e``` test target should pass in CI

Test locally:

1. Login to the cluster as kubeadmin
2. The files ```kubeadmin-password``` and ```kubeconfig``` which contain cluster login details should be present in the auth directory and it should reside in the same directory as Makefile
2. Run ```make prepare-test-cluster```
3. Export these variables 
```
export SERVICE_REPO_URL=https://github.com/<your_github_org_name>/taxi
export GITOPS_REPO_URL=https://github.com/<your_github_org_name>/gitops.git
export IMAGE_REPO=quay.io/<your_quay_user_name>/taxi
export DOCKERCONFIGJSON_PATH=<Docker_credential_file_for_robot_account>
export GITHUB_TOKEN=<your_github_token>
```
4. Run ```make e2e```