### PR TITLE
KAM to function without security manager

### DIFF
--- a/docs/commands/kam_bootstrap.md
+++ b/docs/commands/kam_bootstrap.md
@@ -27,6 +27,7 @@ kam bootstrap [flags]
       --gitops-webhook-secret string    Provide a secret that we can use to authenticate incoming hooks from your Git hosting service for the GitOps repository. (if not provided, it will be auto-generated)
   -h, --help                            help for bootstrap
       --image-repo string               Image repository of the form <registry>/<username>/<repository> or <project>/<app> which is used to push newly built images
+      --insecure                        Set to true to use unencrypted secrets instead of sealed secrets.
       --interactive                     If true, enable prompting for most options if not already specified on the command line
       --output string                   Path to write GitOps resources (default "./gitops")
       --overwrite                       Overwrites previously existing GitOps configuration (if any) on the local filesystem

--- a/docs/commands/kam_service.md
+++ b/docs/commands/kam_service.md
@@ -27,6 +27,7 @@ add
       --git-repo-url string         GitOps repository e.g. https://github.com/organisation/repository - only needed when you need to rebuild the source image for the environment
   -h, --help                        help for service
       --image-repo string           Image registry of the form <registry>/<username>/<image name> or <project>/<app> which is used to push newly built images
+      --insecure                    Set to true to use unencrypted secrets instead of sealed secrets.
       --pipelines-folder string     Folder path to retrieve manifest, eg. /test where manifest exists at /test/pipelines.yaml (default ".")
       --sealed-secrets-ns string    Namespace in which the Sealed Secrets operator is installed, automatically generated secrets are encrypted with this operator (default "cicd")
       --sealed-secrets-svc string   Name of the Sealed Secrets services that encrypts secrets (default "sealedsecretcontroller-sealed-secrets")

--- a/docs/commands/kam_service_add.md
+++ b/docs/commands/kam_service_add.md
@@ -25,6 +25,7 @@ kam service add [flags]
       --git-repo-url string         GitOps repository e.g. https://github.com/organisation/repository - only needed when you need to rebuild the source image for the environment
   -h, --help                        help for add
       --image-repo string           Image registry of the form <registry>/<username>/<image name> or <project>/<app> which is used to push newly built images
+      --insecure                    Set to true to use unencrypted secrets instead of sealed secrets.
       --pipelines-folder string     Folder path to retrieve manifest, eg. /test where manifest exists at /test/pipelines.yaml (default ".")
       --sealed-secrets-ns string    Namespace in which the Sealed Secrets operator is installed, automatically generated secrets are encrypted with this operator (default "cicd")
       --sealed-secrets-svc string   Name of the Sealed Secrets services that encrypts secrets (default "sealedsecretcontroller-sealed-secrets")

--- a/docs/journey/day1/README.md
+++ b/docs/journey/day1/README.md
@@ -15,6 +15,10 @@ You need to have the following installed in the OCP 4.x cluster.
 
 * [OpenShift GitOps Operator](prerequisites/gitops_operator.md)
 * [Sealed Secrets Operator](prerequisites/sealed_secrets.md)
+    * If you opt to not install the Sealed Secrets Operator, the `kam bootstrap` and `kam service add` commands will generate unencrypted or unsealed secrets in the `secrets` folder that is a sibling folder of the designated output folder that contains the GitOps configuration files.
+    * The `secrets` folder will not be staged for commit via Git, since it is outside of the designated output folder.  This is necessary so that the unencrypted secrets are not inadvertantly pushed to GitHub.
+    * WARNING: using unsealed unencrypted secrets is not recommended.
+    
 
 And, you will need these:
 

--- a/docs/journey/day2/README.md
+++ b/docs/journey/day2/README.md
@@ -157,9 +157,11 @@ The new Service/Application will be deployed by ArgoCD. An ArgoCD application ya
 
 In the CI/CD Environment, a couple of resources are added or modified.
 
-A Webhook secret resource is generated:
+A Webhook secret resource is generated, if the Sealed Secrets Operator is available:
 
 * `config/cicd/base/03-secrets/webhook-secret-<env>-<service>.yaml`
+
+If the Sealed Secrets Operator is not installed, then an unencryped secret is generated into  the `secrets` folder that is a sibling of the folder that contains the `pipelines.yaml` file (or the parent of the `config` folder)
 
 The Event Listener is modified as below to add a `trigger` for the new Service's source repository to trigger continous integration:
 

--- a/pkg/cmd/bootstrap_test.go
+++ b/pkg/cmd/bootstrap_test.go
@@ -280,7 +280,7 @@ func TestDependenciesWithNothingInstalled(t *testing.T) {
 	fakeClient := newFakeClient(nil, nil)
 
 	wantMsg := `
-Checking if Sealed Secrets is installed with the default configuration [Please install Sealed Secrets Operator from OperatorHub]
+Checking if Sealed Secrets is installed with the default configuration [The Sealed Secrets Controller was not detected]
 Checking if ArgoCD is installed with the default configuration [Please install OpenShift GitOps Operator from OperatorHub]
 Checking if OpenShift Pipelines Operator is installed with the default configuration [Please install OpenShift GitOps Operator from OperatorHub]`
 
@@ -321,7 +321,7 @@ func TestDependenciesWithAllInstalledDifferentSealedSecretsService(t *testing.T)
 
 	// expect negative Sealed Secrets check
 	wantMsg := `
-Checking if Sealed Secrets is installed with the default configuration [Please install Sealed Secrets Operator from OperatorHub]
+Checking if Sealed Secrets is installed with the default configuration [The Sealed Secrets Controller was not detected]
 Checking if ArgoCD is installed with the default configuration
 Checking if OpenShift Pipelines Operator is installed with the default configuration`
 

--- a/pkg/cmd/ui/ui.go
+++ b/pkg/cmd/ui/ui.go
@@ -87,8 +87,9 @@ func EnterImageRepoExternalRepository() string {
 }
 
 // VerifyOutputPath allows the user to specify the path where the gitops configuration must reside locally in a UI prompt.
-func VerifyOutputPath(originalPath string, overwrite, outputPathOverridden, promptForPath bool) string {
+func VerifyOutputPath(originalPath string, overwrite, outputPathOverridden, promptForPath bool) (string, bool) {
 	var outputPath = originalPath
+	var doOverwrite = overwrite
 	prompt := &survey.Input{
 		Message: "Provide a path to write GitOps resources?",
 		Help:    "This is the path where the GitOps repository configuration is stored locally before you push it to the repository GitopsRepoURL",
@@ -104,14 +105,20 @@ func VerifyOutputPath(originalPath string, overwrite, outputPathOverridden, prom
 		if !exists || overwrite {
 			break
 		}
-		doOverwrite := SelectOptionOverwrite(outputPath)
+		doOverwrite = SelectOptionOverwrite(outputPath)
 		if doOverwrite {
 			break
 		}
 		handleError(survey.AskOne(prompt, &outputPath, nil))
 		outputPath = strings.TrimSpace(outputPath)
 	}
-	return outputPath
+	return outputPath, doOverwrite
+}
+
+func VerifySecretsPath(outputPath string) bool {
+	exists, err := ioutils.IsExisting(ioutils.NewFilesystem(), filepath.Join(outputPath, "..", "secrets"))
+	handleError(err)
+	return exists
 }
 
 // EnterGitWebhookSecret allows the user to specify the webhook secret string

--- a/pkg/cmd/utility/utility.go
+++ b/pkg/cmd/utility/utility.go
@@ -17,6 +17,12 @@ const (
 	argocdCRD = "argocds.argoproj.io"
 )
 
+type Status interface {
+	WarningStatus(status string)
+	Start(status string, debug bool)
+	End(status bool)
+}
+
 // AddGitSuffixIfNecessary will append .git to URL if necessary
 func AddGitSuffixIfNecessary(url string) string {
 	if url == "" || strings.HasSuffix(strings.ToLower(url), ".git") {
@@ -109,4 +115,10 @@ func (c *Client) CheckIfPipelinesExists(ns string) error {
 // GetFullName generates a command's full name based on its parent's full name and its own name
 func GetFullName(parentName, name string) string {
 	return parentName + " " + name
+}
+
+// DisplayUnsealedSecretsWarning display unsealed secrets warning
+func DisplayUnsealedSecretsWarning() {
+	log.Progressf("  WARNING: Unencrypted secrets will be created in a secrets folder that is a sibling to the designated output or pipelines folder")
+	log.Progressf("           Deploying this GitOps configuration without encrypting secrets is insecure and is not recommended")
 }

--- a/pkg/pipelines/secrets/secrets.go
+++ b/pkg/pipelines/secrets/secrets.go
@@ -51,6 +51,15 @@ func CreateSealedDockerConfigSecret(name, service types.NamespacedName, in io.Re
 	return seal(secret, DefaultPublicKeyFunc, service)
 }
 
+// CreateUnsealedDockerConfigSecret creates an Unsealed Secret with the given name and reader
+func CreateUnsealedDockerConfigSecret(name, service types.NamespacedName, in io.Reader) (*corev1.Secret, error) {
+	secret, err := createDockerConfigSecret(name, in)
+	if err != nil {
+		return nil, err
+	}
+	return secret, nil
+}
+
 // CreateSealedSecret creates a SealedSecret with the provided name and body/data and type
 func CreateSealedSecret(name, service types.NamespacedName, data, secretKey string) (*ssv1alpha1.SealedSecret, error) {
 	secret, err := createOpaqueSecret(name, data, secretKey)
@@ -61,11 +70,26 @@ func CreateSealedSecret(name, service types.NamespacedName, data, secretKey stri
 	return seal(secret, DefaultPublicKeyFunc, service)
 }
 
+func CreateUnsealedSecret(name, service types.NamespacedName, data, secretKey string) (*corev1.Secret, error) {
+	secret, err := createOpaqueSecret(name, data, secretKey)
+	if err != nil {
+		return nil, err
+	}
+	return secret, nil
+}
+
 // CreateSealedBasicAuthSecret creates a SealedSecret with a BasicAuth type
 // secret.
 func CreateSealedBasicAuthSecret(name, service types.NamespacedName, token string,
 	opts ...meta.ObjectMetaOpt) (*ssv1alpha1.SealedSecret, error) {
 	return seal(createBasicAuthSecret(name, token, opts...), DefaultPublicKeyFunc, service)
+}
+
+// CreateUnsealedBasicAuthSecret creates a SealedSecret with a BasicAuth type
+// secret.
+func CreateUnsealedBasicAuthSecret(name, service types.NamespacedName, token string,
+	opts ...meta.ObjectMetaOpt) *corev1.Secret {
+	return createBasicAuthSecret(name, token, opts...)
 }
 
 // Returns a sealed secret


### PR DESCRIPTION
Signed-off-by: Keith Chong <kykchong@redhat.com>

**What type of PR is this?**

/kind enhancement

**What does this PR do / why we need it**:
For those cases where customers did not install the Sealed Secrets Operator, we need KAM to still work without generating sealed secrets.  We will generate the unencrypted/unsealed secrets which can be secured separately.

**Have you updated the necessary documentation?**

* [x] Documentation update is required by this PR.
* [x] Documentation has been updated.  See https://github.com/redhat-developer/kam/pull/182

**Which issue(s) this PR fixes**:
See https://issues.redhat.com/browse/GITOPS-677

**How to test changes / Special notes to the reviewer**:
Kevin wanted a new flag `--insecure` flag to give users the capability to force using unencrypted secrets and not by simply failing on the check that the sealed secrets operator is not installed.
