### PR TITLE
fixed panic for invalid gitops/service repo URL

### DIFF
--- a/pkg/cmd/bootstrap.go
+++ b/pkg/cmd/bootstrap.go
@@ -165,7 +165,15 @@ func initiateInteractiveMode(io *BootstrapParameters, client *utility.Client, cm
 		io.SealedSecretsService.Namespace = ui.EnterSealedSecretService(&io.SealedSecretsService)
 	}
 	if io.GitOpsRepoURL == "" {
-		io.GitOpsRepoURL = ui.EnterGitRepo()
+		gitopsRepoURL := ui.EnterGitRepo()
+		p, err := url.Parse(gitopsRepoURL)
+		if err != nil {
+			return fmt.Errorf("Invalid URL, err: %v", err)
+		}
+		if p.Host == "" {
+			return fmt.Errorf("could not identify host from %q", gitopsRepoURL)
+		}
+		io.GitOpsRepoURL = p.Host
 	}
 	io.GitOpsRepoURL = utility.AddGitSuffixIfNecessary(io.GitOpsRepoURL)
 	if !isKnownDriver(io.GitOpsRepoURL) {
@@ -200,7 +208,15 @@ func initiateInteractiveMode(io *BootstrapParameters, client *utility.Client, cm
 		io.GitOpsWebhookSecret = ui.EnterGitWebhookSecret(io.GitOpsRepoURL)
 	}
 	if io.ServiceRepoURL == "" {
-		io.ServiceRepoURL = ui.EnterServiceRepoURL()
+		serviceRepoURL := ui.EnterServiceRepoURL()
+		p, err := url.Parse(serviceRepoURL)
+		if err != nil {
+			return fmt.Errorf("Invalid URL, err: %v", err)
+		}
+		if p.Host == "" {
+			return fmt.Errorf("could not identify host from %q", serviceRepoURL)
+		}
+		io.ServiceRepoURL = p.Host
 	}
 	io.ServiceRepoURL = utility.AddGitSuffixIfNecessary(io.ServiceRepoURL)
 	if promptForAll {

--- a/pkg/cmd/bootstrap.go
+++ b/pkg/cmd/bootstrap.go
@@ -165,15 +165,7 @@ func initiateInteractiveMode(io *BootstrapParameters, client *utility.Client, cm
 		io.SealedSecretsService.Namespace = ui.EnterSealedSecretService(&io.SealedSecretsService)
 	}
 	if io.GitOpsRepoURL == "" {
-		gitopsRepoURL := ui.EnterGitRepo()
-		p, err := url.Parse(gitopsRepoURL)
-		if err != nil {
-			return fmt.Errorf("Invalid URL, err: %v", err)
-		}
-		if p.Host == "" {
-			return fmt.Errorf("could not identify host from %q", gitopsRepoURL)
-		}
-		io.GitOpsRepoURL = p.Host
+		io.GitOpsRepoURL = ui.EnterGitRepo()
 	}
 	io.GitOpsRepoURL = utility.AddGitSuffixIfNecessary(io.GitOpsRepoURL)
 	if !isKnownDriver(io.GitOpsRepoURL) {
@@ -208,15 +200,7 @@ func initiateInteractiveMode(io *BootstrapParameters, client *utility.Client, cm
 		io.GitOpsWebhookSecret = ui.EnterGitWebhookSecret(io.GitOpsRepoURL)
 	}
 	if io.ServiceRepoURL == "" {
-		serviceRepoURL := ui.EnterServiceRepoURL()
-		p, err := url.Parse(serviceRepoURL)
-		if err != nil {
-			return fmt.Errorf("Invalid URL, err: %v", err)
-		}
-		if p.Host == "" {
-			return fmt.Errorf("could not identify host from %q", serviceRepoURL)
-		}
-		io.ServiceRepoURL = p.Host
+		io.ServiceRepoURL = ui.EnterServiceRepoURL()
 	}
 	io.ServiceRepoURL = utility.AddGitSuffixIfNecessary(io.ServiceRepoURL)
 	if promptForAll {

--- a/pkg/cmd/ui/ui.go
+++ b/pkg/cmd/ui/ui.go
@@ -18,7 +18,7 @@ func EnterGitRepo() string {
 		Message: "Provide the URL for your GitOps repository",
 		Help:    "The GitOps repository stores your GitOps configuration files, including your Openshift Pipelines resources for driving automated deployments and builds.  Please enter a valid git repository e.g. https://github.com/example/myorg.git",
 	}
-	err := survey.AskOne(prompt, &gitOpsURL, survey.Required)
+	err := survey.AskOne(prompt, &gitOpsURL, makeURLValidatorCheck())
 	handleError(err)
 	return strings.TrimSpace(gitOpsURL)
 }
@@ -178,7 +178,7 @@ func EnterServiceRepoURL() string {
 		Message: "Provide the URL for your Service repository e.g. https://github.com/organisation/service.git",
 		Help:    "The repository name where the source code of your service is situated, this will configure a very basic CI for this repository using OpenShift pipelines.",
 	}
-	err := survey.AskOne(prompt, &serviceRepo, survey.Required)
+	err := survey.AskOne(prompt, &serviceRepo, makeURLValidatorCheck())
 	handleError(err)
 	return strings.TrimSpace(serviceRepo)
 }

--- a/pkg/cmd/ui/ui.go
+++ b/pkg/cmd/ui/ui.go
@@ -2,7 +2,6 @@ package ui
 
 import (
 	"fmt"
-	"net/url"
 	"path/filepath"
 	"strings"
 
@@ -21,13 +20,7 @@ func EnterGitRepo() string {
 	}
 	err := survey.AskOne(prompt, &gitOpsURL, survey.Required)
 	handleError(err)
-	gitOpsURL = strings.TrimSpace(gitOpsURL)
-	p, err := url.Parse(gitOpsURL)
-	handleError(err)
-	if p.Host == "" {
-		handleError(fmt.Errorf("could not identify host from %q", gitOpsURL))
-	}
-	return gitOpsURL
+	return strings.TrimSpace(gitOpsURL)
 }
 
 // EnterInternalRegistry allows the user to specify the internal registry in a UI prompt.
@@ -187,13 +180,7 @@ func EnterServiceRepoURL() string {
 	}
 	err := survey.AskOne(prompt, &serviceRepo, survey.Required)
 	handleError(err)
-	serviceRepo = strings.TrimSpace(serviceRepo)
-	p, err := url.Parse(serviceRepo)
-	handleError(err)
-	if p.Host == "" {
-		handleError(fmt.Errorf("could not identify host from %q", serviceRepo))
-	}
-	return serviceRepo
+	return strings.TrimSpace(serviceRepo)
 }
 
 // EnterServiceWebhookSecret allows the user to specify the webhook secret string they wish to authenticate push/pull to service repo in a UI prompt.

--- a/pkg/cmd/ui/validate.go
+++ b/pkg/cmd/ui/validate.go
@@ -43,6 +43,12 @@ func makeAccessTokenCheck(serviceRepo string) survey.Validator {
 	}
 }
 
+func makeURLValidatorCheck() survey.Validator {
+	return func(input interface{}) error {
+		return validateURL(input)
+	}
+}
+
 // ValidatePrefix checks the length of the prefix with the env crosses 63 chars or not
 func validatePrefix(input interface{}) error {
 	if s, ok := input.(string); ok {
@@ -127,6 +133,19 @@ func validateSealedSecretService(input interface{}, sealedSecretService *types.N
 		sealedSecretService.Namespace = s
 		sealedSecretService.Name = enterSealedSecretService()
 		return client.CheckIfSealedSecretsExists(*sealedSecretService)
+	}
+	return nil
+}
+
+func validateURL(input interface{}) error {
+	if u, ok := input.(string); ok {
+		p, err := url.Parse(u)
+		if err != nil {
+			return fmt.Errorf("invalid URL, err: %v", err)
+		}
+		if p.Host == "" {
+			return fmt.Errorf("could not identify host from %q", u)
+		}
 	}
 	return nil
 }

--- a/pkg/cmd/ui/validate_test.go
+++ b/pkg/cmd/ui/validate_test.go
@@ -75,3 +75,33 @@ func TestAccessToken(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateURL(t *testing.T) {
+
+	validator := makeURLValidatorCheck()
+	cmdTests := []struct {
+		desc     string
+		argument string
+		wantErr  string
+	}{
+		{
+			"Invalid URL format",
+			"gitops repo https://github.com/test/gitops.git",
+			"invalid URL, err: parse \"gitops repo https://github.com/test/gitops.git\": first path segment in URL cannot contain colon",
+		},
+		{
+			"Empty URL",
+			"",
+			"could not identify host from \"\"",
+		},
+	}
+
+	for _, tt := range cmdTests {
+		t.Run(tt.desc, func(t *testing.T) {
+			err := validator(tt.argument)
+			if err.Error() != tt.wantErr {
+				t.Errorf("got %s, want %s", err, tt.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**
> /kind bug

**What does this PR do / why we need it**:
This PR fixes the validation and error handling for invalid GitOps Repo and service repo URLs

**Have you updated the necessary documentation?**

* [x] Documentation update is required by this PR.
* [x] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:

ISSUE:
```
kam bootstrap
Checking dependencies

 ✓  Checking if Sealed Secrets is installed with the default configuration [941ms]
 ✓  Checking if ArgoCD is installed with the default configuration [2s]  
 ✓  Checking if OpenShift Pipelines Operator is installed with the default configuration [2s]
  
Starting interactive prompt

? Do you want to accept all default values and be prompted only for the minimum required options? no
? Provide the URL for your GitOps repository invalid https://testrepo.git
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x30 pc=0x1fb08ec]

goroutine 1 [running]:
github.com/redhat-developer/kam/pkg/cmd/ui.EnterGitRepo(0xc000548240, 0x26ee81a)
	/Users/shubhamagarwal/go/src/github.com/redhat-developer/kam/pkg/cmd/ui/ui.go:27 +0x14c
github.com/redhat-developer/kam/pkg/cmd.initiateInteractiveMode(0xc0007a5dd0, 0xc000548240, 0xc0001218c0, 0xc00033e0c0, 0x0)
	/Users/shubhamagarwal/go/src/github.com/redhat-developer/kam/pkg/cmd/bootstrap.go:168 +0xaf9
github.com/redhat-developer/kam/pkg/cmd.(*BootstrapParameters).Complete(0xc0007a5dd0, 0x26f4b02, 0x9, 0xc0001218c0, 0x351a228, 0x0, 0x0, 0xc000169b00, 0x26ee95a)
	/Users/shubhamagarwal/go/src/github.com/redhat-developer/kam/pkg/cmd/bootstrap.go:115 +0x156
github.com/redhat-developer/kam/pkg/cmd/genericclioptions.GenericRun(0x29199e0, 0xc0007a5dd0, 0xc0001218c0, 0x351a228, 0x0, 0x0)
	/Users/shubhamagarwal/go/src/github.com/redhat-developer/kam/pkg/cmd/genericclioptions/runnable.go:23 +0x6e
github.com/redhat-developer/kam/pkg/cmd.NewCmdBootstrap.func1(0xc0001218c0, 0x351a228, 0x0, 0x0)
	/Users/shubhamagarwal/go/src/github.com/redhat-developer/kam/pkg/cmd/bootstrap.go:408 +0x5e
github.com/spf13/cobra.(*Command).execute(0xc0001218c0, 0x351a228, 0x0, 0x0, 0xc0001218c0, 0x351a228)
	/Users/shubhamagarwal/go/src/github.com/redhat-developer/kam/vendor/github.com/spf13/cobra/command.go:846 +0x2c2
github.com/spf13/cobra.(*Command).ExecuteC(0xc000121600, 0x1008285, 0xc0000480b8, 0x0)
	/Users/shubhamagarwal/go/src/github.com/redhat-developer/kam/vendor/github.com/spf13/cobra/command.go:950 +0x375
github.com/spf13/cobra.(*Command).Execute(...)
	/Users/shubhamagarwal/go/src/github.com/redhat-developer/kam/vendor/github.com/spf13/cobra/command.go:887
github.com/redhat-developer/kam/pkg/cmd.Execute()
	/Users/shubhamagarwal/go/src/github.com/redhat-developer/kam/pkg/cmd/kam.go:43 +0x2a
main.main()
	/Users/shubhamagarwal/go/src/github.com/redhat-developer/kam/cmd/kam/kam.go:8 +0x25
```

TESTING-THE-FIX:
- Initiate interactive Kam bootstrap
- Provide invalid URL when prompted for Gitops Repo URL, for example - "invalid URL https://someurl.git"
- This should throw an Invalid URL error rather than panicking. 

```
kam bootstrap  
Checking dependencies

 ✓  Checking if Sealed Secrets is installed with the default configuration [897ms]
 ✓  Checking if ArgoCD is installed with the default configuration [2s]  
 ✓  Checking if OpenShift Pipelines Operator is installed with the default configuration [2s]
  
Starting interactive prompt

? Do you want to accept all default values and be prompted only for the minimum required options? no
? Provide the URL for your GitOps repository invalid https://testrepo.git
 ✗  Invalid URL, err: parse "invalid https://testrepo.git": first path segment in URL cannot contain colon
```
