### PR TITLE
fix: Update trigger binding to use the new extensions field

### DIFF
--- a/pkg/pipelines/scm/github.go
+++ b/pkg/pipelines/scm/github.go
@@ -50,7 +50,7 @@ func (r *githubSpec) pushBindingParams() []triggersv1.Param {
 	return []triggersv1.Param{
 		createBindingParam("gitrepositoryurl", "$(body.repository.clone_url)"),
 		createBindingParam("fullname", "$(body.repository.full_name)"),
-		createBindingParam(triggers.GitRef, "$(body.ref)"),
+		createBindingParam(triggers.GitRef, "$(extensions.ref)"),
 		createBindingParam(triggers.GitCommitID, "$(body.head_commit.id)"),
 		createBindingParam(triggers.GitCommitDate, "$(body.head_commit.timestamp)"),
 		createBindingParam(triggers.GitCommitMessage, "$(body.head_commit.message)"),

--- a/pkg/pipelines/scm/github_test.go
+++ b/pkg/pipelines/scm/github_test.go
@@ -31,7 +31,7 @@ func TestCreatePushBindingForGithub(t *testing.T) {
 				},
 				{
 					Name:  triggers.GitRef,
-					Value: "$(body.ref)",
+					Value: "$(extensions.ref)",
 				},
 				{
 					Name:  triggers.GitCommitID,

--- a/pkg/pipelines/scm/gitlab.go
+++ b/pkg/pipelines/scm/gitlab.go
@@ -49,7 +49,7 @@ func (r *gitlabSpec) pushBindingParams() []triggersv1.Param {
 	return []triggersv1.Param{
 		createBindingParam("gitrepositoryurl", "$(body.project.git_http_url)"),
 		createBindingParam("fullname", "$(body.project.path_with_namespace)"),
-		createBindingParam(triggers.GitRef, "$(body.ref)"),
+		createBindingParam(triggers.GitRef, "$(extensions.ref)"),
 		createBindingParam(triggers.GitCommitID, "$(body.after)"),
 		createBindingParam(triggers.GitCommitDate, "$(body.commits[-1:].timestamp)"),
 		createBindingParam(triggers.GitCommitMessage, "$(body.commits[-1:].message)"),

--- a/pkg/pipelines/scm/gitlab_test.go
+++ b/pkg/pipelines/scm/gitlab_test.go
@@ -31,7 +31,7 @@ func TestCreatePushBindingForGitlab(t *testing.T) {
 				},
 				{
 					Name:  triggers.GitRef,
-					Value: "$(body.ref)",
+					Value: "$(extensions.ref)",
 				},
 				{
 					Name:  triggers.GitCommitID,


### PR DESCRIPTION
**What type of PR is this?**

> /kind bug


**What does this PR do / why we need it**:

The Overlays in the Tekton event listener will add elements to a new field known as "extensions" instead of modifying the existing fields in the incoming payload.
This PR updates the trigger binding to extract the branch name from the new extensions field.

Overlays Ref: https://github.com/tektoncd/triggers/blob/v0.10.2/docs/eventlisteners.md#overlays 

Signed-off-by: Chetan Banavikalmutt <chetanrns1997@gmail.com>

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.



**How to test changes / Special notes to the reviewer**:

1. Follow Day 1 docs and bootstrap a gitops repository
2. Add webhooks to gitops and service repository
3. Raise PRs to your gitops and service repositories, observe if both the pipelines are successfully executed

![Screenshot from 2021-03-12 11-47-38](https://user-images.githubusercontent.com/21128732/110900503-d88d4700-8328-11eb-91ee-6f19833db506.png)
