### PR TITLE
Remove unnecessary call from OpenShift CI unit test job

### DIFF
--- a/scripts/openshiftci-presubmit-unittests.sh
+++ b/scripts/openshiftci-presubmit-unittests.sh
@@ -16,7 +16,6 @@ export GOLANGCI_LINT_CACHE="/tmp/.cache"
 git describe --always --long --dirty
 go version
 go env
-go mod vendor
 if [[ $(go fmt `go list ./... | grep -v vendor`) ]]; then
     echo "not well formatted sources are found"
     exit 1


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What does this PR do / why we need it**:

Vendor is part of kam repo. So no need to call it again in OpenShift CI

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #?
N/A

**How to test changes / Special notes to the reviewer**:

CI should pass
