### PR TITLE
Disable --commit-status-tracker by default

### DIFF
--- a/docs/commands/kam_bootstrap.md
+++ b/docs/commands/kam_bootstrap.md
@@ -20,7 +20,7 @@ kam bootstrap [flags]
 ### Options
 
 ```
-      --commit-status-tracker           Enable or disable the commit-status-tracker which reports the success/failure of your pipelineruns to GitHub/GitLab (default true)
+      --commit-status-tracker           Enable or disable the commit-status-tracker which reports the success/failure of your pipelineruns to GitHub/GitLab
       --dockercfgjson string            Filepath to config.json which authenticates the image push to the desired image registry  (default "~/.docker/config.json")
       --git-host-access-token string    Used to authenticate repository clones, and commit-status notifications (if enabled). Access token is encrypted and stored on local file system by keyring, will be updated/reused.
       --gitops-repo-url string          Provide the URL for your GitOps repository e.g. https://github.com/organisation/repository.git

--- a/pkg/cmd/bootstrap.go
+++ b/pkg/cmd/bootstrap.go
@@ -216,9 +216,6 @@ func initiateInteractiveMode(io *BootstrapParameters, client *utility.Client, cm
 	} else {
 		io.GitHostAccessToken = secret
 	}
-	if !cmd.Flag("commit-status-tracker").Changed && promptForAll {
-		io.CommitStatusTracker = ui.SetupCommitStatusTracker()
-	}
 	if !cmd.Flag("push-to-git").Changed && promptForAll {
 		io.PushToGit = ui.SelectOptionPushToGit()
 	}
@@ -424,7 +421,7 @@ func NewCmdBootstrap(name, fullName string) *cobra.Command {
 	bootstrapCmd.Flags().StringVar(&o.ServiceWebhookSecret, "service-webhook-secret", "", "Provide a secret that we can use to authenticate incoming hooks from your Git hosting service for the Service repository. (if not provided, it will be auto-generated)")
 	bootstrapCmd.Flags().BoolVar(&o.SaveTokenKeyRing, "save-token-keyring", false, "Explicitly pass this flag to update the git-host-access-token in the keyring on your local machine")
 	bootstrapCmd.Flags().StringVar(&o.PrivateRepoDriver, "private-repo-driver", "", "If your Git repositories are on a custom domain, please indicate which driver to use github or gitlab")
-	bootstrapCmd.Flags().BoolVar(&o.CommitStatusTracker, "commit-status-tracker", true, "Enable or disable the commit-status-tracker which reports the success/failure of your pipelineruns to GitHub/GitLab")
+	bootstrapCmd.Flags().BoolVar(&o.CommitStatusTracker, "commit-status-tracker", false, "Enable or disable the commit-status-tracker which reports the success/failure of your pipelineruns to GitHub/GitLab")
 	bootstrapCmd.Flags().BoolVar(&o.PushToGit, "push-to-git", false, "If true, automatically creates and populates the gitops-repo-url with the generated resources")
 	bootstrapCmd.Flags().BoolVar(&o.Interactive, "interactive", false, "If true, enable prompting for most options if not already specified on the command line")
 	bootstrapCmd.Flags().BoolVar(&o.Insecure, "insecure", false, "Set to true to use unencrypted secrets instead of sealed secrets.")


### PR DESCRIPTION
Signed-off-by: iam-veeramalla <abhishek.veeramalla@gmail.com>

> /kind code-refactoring

**What does this PR do / why we need it**:
Commit status tracker is an experiential project hosted in Tekton.  Tekton will support this feature out of the box in future release.   The current status of commit status tracker is not stable as it has not been kept up-to-date with Tekton APIs changes.   We should hide user visible option to enable commit status tracker for the time being until we switch over to use the native support in Tekton (ref to ticket).

Fixes #?
https://issues.redhat.com/browse/GITOPS-750

**How to test changes / Special notes to the reviewer**:
Follow Day 1 operations to create a new gitops repo and webhook to trigger pipelines. After this change, you should not see the commit status on PR. 

Work In Progress [Do not Merge]
