### PR TITLE
Rename OpenShift GitOps default Argo CD instance name in KAM

### DIFF
--- a/docs/journey/day1/README.md
+++ b/docs/journey/day1/README.md
@@ -290,7 +290,7 @@ On installation of OpenShift GitOps, the operator sets up a ready-to-use Argo CD
 
 ![ArgoCD_Link](img/ArgoCD_Link.png)
 
-For the pre-created Argo CD instance under `openshift-gitops` project, you’ll find the password by switching to the Developer perspective, navigating to the `openshift-gitops` project, and looking under the "Secrets" tab to find the secret for `argocd-cluster-cluster`. Once you copy that secret to your clipboard, you can paste it into the Argo CD login page for password and use `admin` as the username. 
+For the pre-created Argo CD instance under `openshift-gitops` project, you’ll find the password by switching to the Developer perspective, navigating to the `openshift-gitops` project, and looking under the "Secrets" tab to find the secret for `openshift-gitops-cluster`. Once you copy that secret to your clipboard, you can paste it into the Argo CD login page for password and use `admin` as the username. 
 
 ![ArgoCD_ConsoleSecrets](img/ArgoCD_ConsoleSecrets.png)
 
@@ -301,7 +301,7 @@ For the pre-created Argo CD instance under `openshift-gitops` project, you’ll 
 Alternatively, you can fetch this password via the command line by running: 
 
 ```shell
-$ kubectl get secret argocd-cluster-cluster -n openshift-gitops -ojsonpath='{.data.admin\.password}' | base64 -d
+$ kubectl get secret openshift-gitops-cluster -n openshift-gitops -ojsonpath='{.data.admin\.password}' | base64 -d
 ```
 You should now be logged in and able to see the Argo CD UI, and deployed applications should be healthy and in-sync.
 

--- a/pkg/pipelines/argocd/argocd.go
+++ b/pkg/pipelines/argocd/argocd.go
@@ -67,7 +67,7 @@ const (
 
 	defaultServer          = "https://kubernetes.default.svc"
 	defaultProject         = "default"
-	argoCDSAName           = "argocd-cluster-argocd-application-controller"
+	argoCDSAName           = "openshift-gitops-application-controller"
 	argocdAdminBindingName = "argocd-admin"
 )
 

--- a/scripts/setup-operators.sh
+++ b/scripts/setup-operators.sh
@@ -104,4 +104,4 @@ done
 echo "Completed OpenShift GitOps operator installation"
 
 echo "Provide cluster-admin access to argocd-application-controller service account"
-oc adm policy add-cluster-role-to-user cluster-admin system:serviceaccount:openshift-gitops:argocd-cluster-argocd-application-controller
+oc adm policy add-cluster-role-to-user cluster-admin system:serviceaccount:openshift-gitops:openshift-gitops-argocd-application-controller


### PR DESCRIPTION
**What type of PR is this?**
 /kind code-refactoring


**What does this PR do / why we need it**:
The default Argo CD instance name would be changed to **openshift-gitops**  when the https://github.com/redhat-developer/gitops-operator/pull/70 is merged. The associated change has been made in KAM

**Have you updated the necessary documentation?**

* [x] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:
https://issues.redhat.com/projects/GITOPS/issues/GITOPS-776 

Fixes #?

**How to test changes / Special notes to the reviewer**:
Perform the Day 1 operations. All the app should be synced in Argo CD.
