### PR TITLE
Update default ref in the annotation URL

### DIFF
--- a/pkg/pipelines/namespaces/namespaces.go
+++ b/pkg/pipelines/namespaces/namespaces.go
@@ -50,7 +50,7 @@ func Create(name, gitOpsRepoURL string) *corev1.Namespace {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
 			Annotations: map[string]string{
-				vcsURIAnnotation: gitOpsRepoURL + "?ref=main",
+				vcsURIAnnotation: gitOpsRepoURL + "?ref=HEAD",
 			},
 		},
 	}

--- a/pkg/pipelines/namespaces/namespaces_test.go
+++ b/pkg/pipelines/namespaces/namespaces_test.go
@@ -18,7 +18,7 @@ func TestCreate(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "test-environment",
 			Annotations: map[string]string{
-				vcsURIAnnotation: testGitOpsRepoURL + "?ref=main",
+				vcsURIAnnotation: testGitOpsRepoURL + "?ref=HEAD",
 			},
 		},
 	}


### PR DESCRIPTION
**What type of PR is this?**
> /kind cleanup


**What does this PR do / why we need it**:
Once the backend [PR](https://github.com/redhat-developer/gitops-backend/pull/16) to update the default ref goes in, we should update the ref generated by kam 

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.
