### PR TITLE
Adding kubectl binary in openshift CI test container

### DIFF
--- a/scripts/install-kubectl.sh
+++ b/scripts/install-kubectl.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# Platform check
+PLATFORM=`uname -s | awk '{print tolower($0)}'`
+echo "Your platform is $PLATFORM" 
+
+# Download and install kubectl
+echo -e "\nGet kubectl binary\n"
+curl -sSL -o bin/kubectl https://storage.googleapis.com/kubernetes-release/release/v1.20.5/bin/$PLATFORM/amd64/kubectl
+
+# Make the kubectl executable 
+chmod +x bin/kubectl

--- a/scripts/openshiftci-presubmit-all-tests.sh
+++ b/scripts/openshiftci-presubmit-all-tests.sh
@@ -21,6 +21,9 @@ sh $INSTALL_ARGOCD
 INSTALL_DOCKER="./scripts/install-docker-cli.sh"
 sh $INSTALL_DOCKER
 
+INSTALL_KUBECTL="./scripts/install-kubectl.sh"
+sh $INSTALL_KUBECTL
+
 export PATH="$PATH:$(pwd)/bin"
 
 # Copy kubeconfig to temporary kubeconfig file and grant


### PR DESCRIPTION
**What type of PR is this?**

/kind enhancement

**What does this PR do / why we need it**:

To get the argocd admin password we need the kubectl command to execute command ```$ kubectl get secret argocd-cluster-cluster -n openshift-gitops -ojsonpath='{.data.admin\.password}' | base64 -d```. So we need the kubectl binary available in openshift CI test container path.

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #?

N/A

**How to test changes / Special notes to the reviewer**:

In the CI test container kubectl binary should be downloaded to ```bin/``` directory. For local verification you can execute the script ```install-kubectl.sh```  and check the kubectl binary should be downloaded to ```bin/``` directory