### PR TITLE
Locking argocd cli version

### DIFF
--- a/scripts/install-argocd.sh
+++ b/scripts/install-argocd.sh
@@ -1,15 +1,11 @@
 #!/bin/bash
 
-# Find the latest ArgoCD version
-VERSION=$(curl --silent "https://api.github.com/repos/argoproj/argo-cd/releases/latest" | grep '"tag_name"' | sed -E 's/.*"([^"]+)".*/\1/')
-echo $VERSION
-
 # Platform check
 PLATFORM=`uname -s | awk '{print tolower($0)}'`
 echo $PLATFORM 
 
 # Fetch the appropriate OS binary for ArgoCD
-curl -sSL -o bin/argocd https://github.com/argoproj/argo-cd/releases/download/$VERSION/argocd-$PLATFORM-amd64
+curl -sSL -o bin/argocd https://github.com/argoproj/argo-cd/releases/download/v1.8.7/argocd-$PLATFORM-amd64
 
 # Make the argocd CLI executable
 chmod +x bin/argocd


### PR DESCRIPTION
**What type of PR is this?**

/kind enhancement

**What does this PR do / why we need it**:

Locks argocd cli version to v1.8.7

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes - https://github.com/redhat-developer/kam/pull/214#discussion_r604603949

**How to test changes / Special notes to the reviewer**:
```
$ PLATFORM=`uname -s | awk '{print tolower($0)}'`

$ curl -sSL -o bin/argocd https://github.com/argoproj/argo-cd/releases/download/v1.8.7/argocd-$PLATFORM-amd64

$ chmod +x bin/argocd 

$ bin/argocd version
argocd: v1.8.7+eb3d1fb
  BuildDate: 2021-03-03T07:14:50Z
  GitCommit: eb3d1fb84b9b77cdffd70b14c4f949f1c64a9416
  [...]
```