### PR TITLE
The description for the kam service --git-repo-url option is wrong (829)

### DIFF
--- a/docs/commands/kam_service.md
+++ b/docs/commands/kam_service.md
@@ -24,7 +24,7 @@ add
 ```
       --app-name string             Name of the application where the service will be added
       --env-name string             Name of the environment where the service will be added
-      --git-repo-url string         GitOps repository e.g. https://github.com/organisation/repository - only needed when you need to rebuild the source image for the environment
+      --git-repo-url string         Service repository URL e.g. https://github.com/organisation/repository - only needed when you need to rebuild the source image for the environment
   -h, --help                        help for service
       --image-repo string           Image registry of the form <registry>/<username>/<image name> or <project>/<app> which is used to push newly built images
       --insecure                    Set to true to use unencrypted secrets instead of sealed secrets.

--- a/docs/commands/kam_service_add.md
+++ b/docs/commands/kam_service_add.md
@@ -22,7 +22,7 @@ kam service add [flags]
 ```
       --app-name string             Name of the application where the service will be added
       --env-name string             Name of the environment where the service will be added
-      --git-repo-url string         GitOps repository e.g. https://github.com/organisation/repository - only needed when you need to rebuild the source image for the environment
+      --git-repo-url string         Service repository URL e.g. https://github.com/organisation/repository - only needed when you need to rebuild the source image for the environment
   -h, --help                        help for add
       --image-repo string           Image registry of the form <registry>/<username>/<image name> or <project>/<app> which is used to push newly built images
       --insecure                    Set to true to use unencrypted secrets instead of sealed secrets.

--- a/pkg/cmd/service/add.go
+++ b/pkg/cmd/service/add.go
@@ -117,7 +117,7 @@ func newCmdAdd(name, fullName string) *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVar(&o.GitRepoURL, "git-repo-url", "", "GitOps repository e.g. https://github.com/organisation/repository - only needed when you need to rebuild the source image for the environment")
+	cmd.Flags().StringVar(&o.GitRepoURL, "git-repo-url", "", "Service repository URL e.g. https://github.com/organisation/repository - only needed when you need to rebuild the source image for the environment")
 	cmd.Flags().StringVar(&o.WebhookSecret, "webhook-secret", "", "Source Git repository webhook secret (if not provided, it will be auto-generated)")
 	cmd.Flags().StringVar(&o.AppName, "app-name", "", "Name of the application where the service will be added")
 	cmd.Flags().StringVar(&o.ServiceName, "service-name", "", "Name of the service to be added")


### PR DESCRIPTION
Signed-off-by: Keith Chong <kykchong@redhat.com>

**What type of PR is this?**
/kind bug

**What does this PR do / why we need it**:
Misleading information

**Have you updated the necessary documentation?**

* [x] Documentation update is required by this PR.
* [x] Documentation has been updated.

**Which issue(s) this PR fixes**:
https://issues.redhat.com/browse/GITOPS-829

**How to test changes / Special notes to the reviewer**:
Run: kam service -h and look at the description of the --git-repo-url flag
Currently, it says:
GitOps repository e.g. https://github.com/organisation/repository - only needed when you need to rebuild the source image for the environment