### PR TITLE
Insecure option is not available in interactive mode (812)

### DIFF
--- a/pkg/cmd/bootstrap.go
+++ b/pkg/cmd/bootstrap.go
@@ -156,6 +156,9 @@ func initiateInteractiveMode(io *BootstrapParameters, client *utility.Client, cm
 	promptForAll := !ui.UseDefaultValues()
 	// ask for sealed secrets only when default is absent, and consider insecure/secure cases
 	err := client.CheckIfSealedSecretsExists(defaultSealedSecretsServiceName)
+	if !cmd.Flag("insecure").Changed && promptForAll {
+		io.Insecure = ui.SelectInsecureSecrets(err)
+	}
 	if !io.Insecure && err != nil {
 		io.SealedSecretsService.Namespace = ui.EnterSealedSecretService(&io.SealedSecretsService)
 	}

--- a/pkg/cmd/ui/ui.go
+++ b/pkg/cmd/ui/ui.go
@@ -153,6 +153,24 @@ func EnterSealedSecretService(sealedSecretService *types.NamespacedName) string 
 	return strings.TrimSpace(sealedNs)
 }
 
+// SelectInsecureSecrets, prompts the UI to ask to generate unsealed secrets or not
+func SelectInsecureSecrets(err error) bool {
+	var insecure, msg string
+	if err != nil {
+		msg = "Do you want to use 1) unsealed secrets or 2) sealed secrets and provide the details of the Sealed Secrets Operator installation?"
+	} else {
+		msg = "You are able to seal secrets. Select Sealed to continue or Unsealed to generate unsealed secrets, which is not recommended."
+	}
+	prompt := &survey.Select{
+		Message: msg,
+		Help:    "WARNING: Deploying the GitOps configuration without encrypting secrets is insecure and is not recommended",
+		Options: []string{"Sealed", "Unsealed"},
+		Default: "Sealed",
+	}
+	handleError(survey.AskOne(prompt, &insecure, survey.Required))
+	return insecure == "Unsealed"
+}
+
 // EnterGitHostAccessToken , it becomes necessary to add the personal access
 // token to access upstream git hosts.
 func EnterGitHostAccessToken(serviceRepo string) string {


### PR DESCRIPTION
Signed-off-by: Keith Chong <kykchong@redhat.com>

**What type of PR is this?**
> /kind enhancement
We wanted to force users to specify --insecure from the command line because it is not a recommend option.  But for consistency, we should add it in interactive mode.  The message should be carefully worded to indicate it is not recommended.

**What does this PR do / why we need it**:
Make --insecure option available in interactive mode

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

https://issues.redhat.com/browse/GITOPS-812


**How to test changes / Special notes to the reviewer**:
See https://issues.redhat.com/browse/GITOPS-812 for scenarios and interactive mode examples.
