### PR TITLE
bug: delete existing .git directory if push-to-git and overwrite are set

### DIFF
--- a/pkg/cmd/bootstrap.go
+++ b/pkg/cmd/bootstrap.go
@@ -233,17 +233,14 @@ func initiateInteractiveMode(io *BootstrapParameters, client *utility.Client, cm
 		}
 		io.OutputPath = filepath.Join(".", repoName)
 	}
-	io.OutputPath, io.Overwrite = ui.VerifyOutputPath(io.OutputPath, io.Overwrite, outputPathOverridden, promptForAll)
-	if !io.Overwrite && io.PushToGit {
-		exists := ui.VerifyGitPath(io.OutputPath)
-		if exists {
-			return fmt.Errorf("the .git folder in output path %s already exists. Delete or rename the .git folder and try again", io.OutputPath)
-		}
-	}
+	appFs := ioutils.NewFilesystem()
+	io.OutputPath, io.Overwrite = ui.VerifyOutputPath(appFs, io.OutputPath, io.Overwrite, outputPathOverridden, promptForAll)
 	if !io.Overwrite {
-		exists := ui.VerifySecretsPath(io.OutputPath)
-		if exists {
+		if ui.PathExists(appFs, filepath.Join(io.OutputPath, "..", "secrets")) {
 			return fmt.Errorf("the secrets folder located as a sibling of the output folder %s already exists. Delete or rename the secrets folder and try again", io.OutputPath)
+		}
+		if io.PushToGit && ui.PathExists(appFs, filepath.Join(io.OutputPath, ".git")) {
+			return fmt.Errorf("the .git folder in output path %s already exists. Delete or rename the .git folder and try again", io.OutputPath)
 		}
 	}
 	return nil

--- a/pkg/cmd/ui/ui.go
+++ b/pkg/cmd/ui/ui.go
@@ -108,6 +108,12 @@ func VerifyOutputPath(originalPath string, overwrite, outputPathOverridden, prom
 	return outputPath, doOverwrite
 }
 
+func VerifyGitPath(outputPath string) bool {
+	exists, err := ioutils.IsExisting(ioutils.NewFilesystem(), filepath.Join(outputPath, ".git"))
+	handleError(err)
+	return exists
+}
+
 func VerifySecretsPath(outputPath string) bool {
 	exists, err := ioutils.IsExisting(ioutils.NewFilesystem(), filepath.Join(outputPath, "..", "secrets"))
 	handleError(err)

--- a/pkg/cmd/ui/ui.go
+++ b/pkg/cmd/ui/ui.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/redhat-developer/kam/pkg/pipelines/ioutils"
+	"github.com/spf13/afero"
 	"gopkg.in/AlecAivazis/survey.v1"
 
 	"k8s.io/apimachinery/pkg/types"
@@ -80,7 +81,7 @@ func EnterImageRepoExternalRepository() string {
 }
 
 // VerifyOutputPath allows the user to specify the path where the gitops configuration must reside locally in a UI prompt.
-func VerifyOutputPath(originalPath string, overwrite, outputPathOverridden, promptForPath bool) (string, bool) {
+func VerifyOutputPath(appFs afero.Fs, originalPath string, overwrite, outputPathOverridden, promptForPath bool) (string, bool) {
 	var outputPath = originalPath
 	var doOverwrite = overwrite
 	prompt := &survey.Input{
@@ -93,7 +94,7 @@ func VerifyOutputPath(originalPath string, overwrite, outputPathOverridden, prom
 		outputPath = strings.TrimSpace(outputPath)
 	}
 	for true {
-		exists, err := ioutils.IsExisting(ioutils.NewFilesystem(), filepath.Join(outputPath, "pipelines.yaml"))
+		exists, err := ioutils.IsExisting(appFs, filepath.Join(outputPath, "pipelines.yaml"))
 		handleError(err)
 		if !exists || overwrite {
 			break
@@ -108,14 +109,8 @@ func VerifyOutputPath(originalPath string, overwrite, outputPathOverridden, prom
 	return outputPath, doOverwrite
 }
 
-func VerifyGitPath(outputPath string) bool {
-	exists, err := ioutils.IsExisting(ioutils.NewFilesystem(), filepath.Join(outputPath, ".git"))
-	handleError(err)
-	return exists
-}
-
-func VerifySecretsPath(outputPath string) bool {
-	exists, err := ioutils.IsExisting(ioutils.NewFilesystem(), filepath.Join(outputPath, "..", "secrets"))
+func PathExists(appFs afero.Fs, path string) bool {
+	exists, err := ioutils.IsExisting(appFs, path)
 	handleError(err)
 	return exists
 }

--- a/pkg/pipelines/bootstrap.go
+++ b/pkg/pipelines/bootstrap.go
@@ -92,6 +92,7 @@ type BootstrapOptions struct {
 	PrivateRepoDriver        string               // Records the type of the GitOpsRepoURL driver if not a well-known host.
 	CommitStatusTracker      bool                 // If true, this is a "private repository", i.e. requires authentication to clone the repository.
 	Insecure                 bool                 // If true, use unencrypted, unsealed secrets. By default, sealed secrets are generated.
+	PushToGit                bool                 // records whether or not the repository should be pushed to git.
 }
 
 // PolicyRules to be bound to service account
@@ -133,7 +134,7 @@ var (
 // Bootstrap is the entry-point from the CLI for bootstrapping the GitOps
 // configuration.
 func Bootstrap(o *BootstrapOptions, appFs afero.Fs) error {
-	err := checkPipelinesFileExists(appFs, o.OutputPath, o.Overwrite)
+	err := checkPipelinesFileExists(appFs, o.OutputPath, o.Overwrite, o.PushToGit)
 	if err != nil {
 		return err
 	}
@@ -461,20 +462,36 @@ func defaultPipelines(r scm.Repository) *config.Pipelines {
 }
 
 // Checks whether the pipelines.yaml is present in the output path specified.
-func checkPipelinesFileExists(appFs afero.Fs, outputPath string, overWrite bool) error {
-	exists, _ := ioutils.IsExisting(appFs, filepath.Join(outputPath, pipelinesFile))
-	if exists && !overWrite {
-		return fmt.Errorf("pipelines.yaml in output path already exists. If you want to replace your existing files, please rerun with --overwrite")
+func checkPipelinesFileExists(appFs afero.Fs, outputPath string, overWrite bool, pushToGit bool) error {
+
+	if overWrite {
+		return nil
 	}
 
-	secretsFolderExists, _ := ioutils.IsExisting(ioutils.NewFilesystem(), filepath.Join(outputPath, "..", "secrets"))
-	if secretsFolderExists && !overWrite {
+	if pushToGit {
+		if err := errorIfFileExists(appFs, outputPath, ".git"); err != nil {
+			return err
+		}
+	}
+
+	if err := errorIfFileExists(appFs, outputPath, pipelinesFile); err != nil {
+		return err
+	}
+
+	secretsFolderExists, _ := ioutils.IsExisting(appFs, filepath.Join(outputPath, "..", "secrets"))
+	if secretsFolderExists {
 		return fmt.Errorf("the secrets folder located as a sibling of the output folder %s already exists. Rerun with --overwrite", outputPath)
 	}
 
-	gitDirectoryExists, _ := ioutils.IsExisting(ioutils.NewFilesystem(), filepath.Join(outputPath, ".git"))
-	if gitDirectoryExists && !overWrite {
-		return fmt.Errorf(".git in output path already exists. If you want to replace your existing files, please rerun with --overwrite")
+	return nil
+}
+
+func errorIfFileExists(appFs afero.Fs, outputPath string, files ...string) error {
+	for _, file := range files {
+		exists, _ := ioutils.IsExisting(appFs, filepath.Join(outputPath, file))
+		if exists {
+			return fmt.Errorf("%s in output path already exists. If you want to replace your existing files, please rerun with --overwrite", file)
+		}
 	}
 	return nil
 }

--- a/pkg/pipelines/bootstrap.go
+++ b/pkg/pipelines/bootstrap.go
@@ -471,6 +471,11 @@ func checkPipelinesFileExists(appFs afero.Fs, outputPath string, overWrite bool)
 	if secretsFolderExists && !overWrite {
 		return fmt.Errorf("the secrets folder located as a sibling of the output folder %s already exists. Rerun with --overwrite", outputPath)
 	}
+
+	gitDirectoryExists, _ := ioutils.IsExisting(ioutils.NewFilesystem(), filepath.Join(outputPath, ".git"))
+	if gitDirectoryExists && !overWrite {
+		return fmt.Errorf(".git in output path already exists. If you want to replace your existing files, please rerun with --overwrite")
+	}
 	return nil
 }
 

--- a/pkg/pipelines/bootstrap.go
+++ b/pkg/pipelines/bootstrap.go
@@ -92,7 +92,7 @@ type BootstrapOptions struct {
 	PrivateRepoDriver        string               // Records the type of the GitOpsRepoURL driver if not a well-known host.
 	CommitStatusTracker      bool                 // If true, this is a "private repository", i.e. requires authentication to clone the repository.
 	Insecure                 bool                 // If true, use unencrypted, unsealed secrets. By default, sealed secrets are generated.
-	PushToGit                bool                 // records whether or not the repository should be pushed to git.
+	PushToGit                bool                 // If true, gitops repository is pushed to remote git repository.
 }
 
 // PolicyRules to be bound to service account

--- a/pkg/pipelines/bootstrap.go
+++ b/pkg/pipelines/bootstrap.go
@@ -467,14 +467,12 @@ func checkPipelinesFileExists(appFs afero.Fs, outputPath string, overWrite bool,
 	if overWrite {
 		return nil
 	}
-
+	checkList := []string{pipelinesFile}
 	if pushToGit {
-		if err := errorIfFileExists(appFs, outputPath, ".git"); err != nil {
-			return err
-		}
+		checkList = append(checkList, ".git")
 	}
 
-	if err := errorIfFileExists(appFs, outputPath, pipelinesFile); err != nil {
+	if err := errorIfFileExists(appFs, outputPath, checkList...); err != nil {
 		return err
 	}
 

--- a/pkg/pipelines/bootstrap_test.go
+++ b/pkg/pipelines/bootstrap_test.go
@@ -3,7 +3,6 @@ package pipelines
 import (
 	"crypto/rand"
 	"crypto/rsa"
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -392,8 +391,9 @@ func TestOverwriteFlagExistingGitDirectory(t *testing.T) {
 		ServiceRepoURL:       testSvcRepo,
 		ServiceWebhookSecret: "456",
 		OutputPath:           "/tmp",
+		PushToGit:            true,
 	}
-	err := os.MkdirAll(filepath.Join(params.OutputPath, ".git"), 0755)
+	err := fakeFs.MkdirAll(filepath.Join(params.OutputPath, ".git"), 0755)
 	assertNoError(t, err)
 
 	got := Bootstrap(params, fakeFs)

--- a/pkg/pipelines/bootstrap_test.go
+++ b/pkg/pipelines/bootstrap_test.go
@@ -3,6 +3,8 @@ package pipelines
 import (
 	"crypto/rand"
 	"crypto/rsa"
+	"os"
+	"path/filepath"
 	"testing"
 
 	ssv1alpha1 "github.com/bitnami-labs/sealed-secrets/pkg/apis/sealed-secrets/v1alpha1"
@@ -372,6 +374,37 @@ func TestOverwriteFlag(t *testing.T) {
 	if diff := cmp.Diff(want, got.Error()); diff != "" {
 		t.Fatalf("overwrite failed:\n%s", diff)
 	}
+}
+
+func TestOverwriteFlagExistingGitDirectory(t *testing.T) {
+	defer func(f secrets.PublicKeyFunc) {
+		secrets.DefaultPublicKeyFunc = f
+	}(secrets.DefaultPublicKeyFunc)
+
+	secrets.DefaultPublicKeyFunc = makeTestKey(t)
+	fakeFs := ioutils.NewMemoryFilesystem()
+	params := &BootstrapOptions{
+		Prefix:               "tst-",
+		GitOpsRepoURL:        testGitOpsRepo,
+		ImageRepo:            "image/repo",
+		GitOpsWebhookSecret:  "123",
+		GitHostAccessToken:   "test-token",
+		ServiceRepoURL:       testSvcRepo,
+		ServiceWebhookSecret: "456",
+		OutputPath:           "/tmp",
+	}
+	err := os.MkdirAll(filepath.Join(params.OutputPath, ".git"), 0755)
+	assertNoError(t, err)
+
+	got := Bootstrap(params, fakeFs)
+	want := ".git in output path already exists. If you want to replace your existing files, please rerun with --overwrite"
+	if diff := cmp.Diff(want, got.Error()); diff != "" {
+		t.Fatalf("overwrite failed:\n%s", diff)
+	}
+
+	params.Overwrite = true
+	err = Bootstrap(params, fakeFs)
+	fatalIfError(t, err)
 }
 
 func TestCreateManifest(t *testing.T) {

--- a/pkg/pipelines/utils.go
+++ b/pkg/pipelines/utils.go
@@ -77,8 +77,7 @@ func BootstrapRepository(o *BootstrapOptions, f clientFactory, e executor) error
 }
 
 func pushRepository(o *BootstrapOptions, remote string, e executor) error {
-	exists, _ := ioutils.IsExisting(ioutils.NewFilesystem(), filepath.Join(o.OutputPath, ".git"))
-	if exists {
+	if exists, _ := ioutils.IsExisting(ioutils.NewFilesystem(), filepath.Join(o.OutputPath, ".git")); exists {
 		if err := os.RemoveAll(filepath.Join(o.OutputPath, ".git")); err != nil {
 			return fmt.Errorf("failed to remove existing .git folder in %q: %s", o.OutputPath, err)
 		}

--- a/pkg/pipelines/utils.go
+++ b/pkg/pipelines/utils.go
@@ -86,13 +86,13 @@ func pushRepository(o *BootstrapOptions, remote string, e executor) error {
 	if out, err := e.execute(o.OutputPath, "git", "branch", "-m", "main"); err != nil {
 		return fmt.Errorf("failed to switch to branch 'main' in repository in %q %q: %s", o.OutputPath, string(out), err)
 	}
-	if _, err := e.execute(o.OutputPath, "git", "remote", "show", "origin"); err != nil {
-		if out, err := e.execute(o.OutputPath, "git", "remote", "add", "origin", remote); err != nil {
-			return fmt.Errorf("failed to set remote 'origin' %q to repository in %q %q: %s", remote, o.OutputPath, string(out), err)
-		}
-	} else {
-		if out, err := e.execute(o.OutputPath, "git", "remote", "set-url", "origin", remote); err != nil {
-			return fmt.Errorf("failed to set url for existing remote 'origin' %q to repository in %q %q: %s", remote, o.OutputPath, string(out), err)
+	if out, err := e.execute(o.OutputPath, "git", "remote", "add", "origin", remote); err != nil {
+		if strings.Contains(string(out), "remote origin already exists") {
+			if out, err := e.execute(o.OutputPath, "git", "remote", "set-url", "origin", remote); err != nil {
+				return fmt.Errorf("failed to set url for existing remote 'origin' %q to repository in %q %q: %s", remote, o.OutputPath, string(out), err)
+			}
+		} else {
+			return fmt.Errorf("failed add remote 'origin' %q to repository in %q %q: %s", remote, o.OutputPath, string(out), err)
 		}
 	}
 	if out, err := e.execute(o.OutputPath, "git", "push", "-u", "origin", "main"); err != nil {

--- a/pkg/pipelines/utils.go
+++ b/pkg/pipelines/utils.go
@@ -86,8 +86,14 @@ func pushRepository(o *BootstrapOptions, remote string, e executor) error {
 	if out, err := e.execute(o.OutputPath, "git", "branch", "-m", "main"); err != nil {
 		return fmt.Errorf("failed to switch to branch 'main' in repository in %q %q: %s", o.OutputPath, string(out), err)
 	}
-	if out, err := e.execute(o.OutputPath, "git", "remote", "add", "origin", remote); err != nil {
-		return fmt.Errorf("failed add remote 'origin' %q to repository in %q %q: %s", remote, o.OutputPath, string(out), err)
+	if _, err := e.execute(o.OutputPath, "git", "remote", "show", "origin"); err != nil {
+		if out, err := e.execute(o.OutputPath, "git", "remote", "add", "origin", remote); err != nil {
+			return fmt.Errorf("failed to set remote 'origin' %q to repository in %q %q: %s", remote, o.OutputPath, string(out), err)
+		}
+	} else {
+		if out, err := e.execute(o.OutputPath, "git", "remote", "set-url", "origin", remote); err != nil {
+			return fmt.Errorf("failed to set url for existing remote 'origin' %q to repository in %q %q: %s", remote, o.OutputPath, string(out), err)
+		}
 	}
 	if out, err := e.execute(o.OutputPath, "git", "push", "-u", "origin", "main"); err != nil {
 		return fmt.Errorf("failed push remote to repository %q %q: %s", remote, string(out), err)

--- a/pkg/pipelines/utils_test.go
+++ b/pkg/pipelines/utils_test.go
@@ -64,7 +64,7 @@ func TestBootstrapRepository_with_no_access_token(t *testing.T) {
 	refuteRepositoryCreated(t, fakeData)
 }
 
-func TestPushRepositoryWithSetURL(t *testing.T) {
+func TestPushRepository(t *testing.T) {
 	repo := "git@github.com:testing/testing.git"
 	opts := &BootstrapOptions{
 		OutputPath: "/tmp",
@@ -102,12 +102,7 @@ func TestPushRepositoryWithSetURL(t *testing.T) {
 		{
 			BaseDir: opts.OutputPath,
 			Command: "git",
-			Args:    []string{"remote", "show", "origin"},
-		},
-		{
-			BaseDir: opts.OutputPath,
-			Command: "git",
-			Args:    []string{"remote", "set-url", "origin", repo},
+			Args:    []string{"remote", "add", "origin", repo},
 		},
 		{
 			BaseDir: opts.OutputPath,
@@ -118,14 +113,17 @@ func TestPushRepositoryWithSetURL(t *testing.T) {
 	e.assertCommandsExecuted(t, want)
 }
 
-func TestPushRepositoryWithRemoteAdd(t *testing.T) {
+func TestPushRepositoryWithSetURL(t *testing.T) {
 	repo := "git@github.com:testing/testing.git"
 	opts := &BootstrapOptions{
 		OutputPath: "/tmp",
 	}
 	outputs := [][]byte{
-		[]byte("Initialized empty Git repository in /tmp/.git/"),
+		[]byte("remote origin already exists"),
 		[]byte(""),
+		[]byte(""),
+		[]byte(""),
+		[]byte("Initialized empty Git repository in /tmp/.git/"),
 	}
 	e := newMockExecutor(outputs...)
 	testErr := errors.New("test error")
@@ -134,6 +132,7 @@ func TestPushRepositoryWithRemoteAdd(t *testing.T) {
 	e.errors.push(nil)
 	e.errors.push(nil)
 	e.errors.push(nil)
+
 	err := pushRepository(opts, repo, e)
 	assertNoError(t, err)
 
@@ -161,12 +160,12 @@ func TestPushRepositoryWithRemoteAdd(t *testing.T) {
 		{
 			BaseDir: opts.OutputPath,
 			Command: "git",
-			Args:    []string{"remote", "show", "origin"},
+			Args:    []string{"remote", "add", "origin", repo},
 		},
 		{
 			BaseDir: opts.OutputPath,
 			Command: "git",
-			Args:    []string{"remote", "add", "origin", repo},
+			Args:    []string{"remote", "set-url", "origin", repo},
 		},
 		{
 			BaseDir: opts.OutputPath,

--- a/pkg/pipelines/utils_test.go
+++ b/pkg/pipelines/utils_test.go
@@ -119,6 +119,7 @@ func TestPushRepositoryWithExistingGitDirectory(t *testing.T) {
 	repo := "git@github.com:testing/testing.git"
 	opts := &BootstrapOptions{
 		OutputPath: "/tmp",
+		Overwrite:  true,
 	}
 	outputs := [][]byte{
 		[]byte("Initialized empty Git repository in /tmp/.git/"),
@@ -166,6 +167,7 @@ func TestPushRepositoryWithExistingGitDirectory(t *testing.T) {
 	}
 	e.assertCommandsExecuted(t, want)
 }
+
 func TestPushRepository_handling_errors(t *testing.T) {
 	repo := "git@github.com:testing/testing.git"
 	opts := &BootstrapOptions{

--- a/pkg/pipelines/utils_test.go
+++ b/pkg/pipelines/utils_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/jenkins-x/go-scm/scm"
 	"github.com/jenkins-x/go-scm/scm/driver/fake"
+	"github.com/redhat-developer/kam/pkg/pipelines/ioutils"
 	"github.com/redhat-developer/kam/test"
 )
 
@@ -27,6 +28,7 @@ func TestBootstrapRepository_with_personal_account(t *testing.T) {
 		},
 		factory,
 		newMockExecutor(),
+		ioutils.NewMemoryFilesystem(),
 	)
 	assertNoError(t, err)
 
@@ -45,6 +47,7 @@ func TestBootstrapRepository_with_org(t *testing.T) {
 		},
 		factory,
 		newMockExecutor(),
+		ioutils.NewMemoryFilesystem(),
 	)
 	assertNoError(t, err)
 	assertRepositoryCreated(t, fakeData, "testing", "test-repo")
@@ -61,6 +64,7 @@ func TestBootstrapRepository_with_no_access_token(t *testing.T) {
 		},
 		factory,
 		newMockExecutor(),
+		ioutils.NewMemoryFilesystem(),
 	)
 	assertNoError(t, err)
 	refuteRepositoryCreated(t, fakeData)
@@ -77,7 +81,7 @@ func TestPushRepository(t *testing.T) {
 	}
 	e := newMockExecutor(outputs...)
 
-	err := pushRepository(opts, repo, e)
+	err := pushRepository(opts, repo, e, ioutils.NewMemoryFilesystem())
 	assertNoError(t, err)
 
 	want := []execution{
@@ -130,7 +134,7 @@ func TestPushRepositoryWithExistingGitDirectory(t *testing.T) {
 
 	e := newMockExecutor(outputs...)
 
-	err = pushRepository(opts, repo, e)
+	err = pushRepository(opts, repo, e, ioutils.NewMemoryFilesystem())
 	assertNoError(t, err)
 
 	want := []execution{
@@ -181,7 +185,7 @@ func TestPushRepository_handling_errors(t *testing.T) {
 	e.errors.push(nil)
 	e.errors.push(testErr)
 
-	err := pushRepository(opts, repo, e)
+	err := pushRepository(opts, repo, e, ioutils.NewMemoryFilesystem())
 	test.AssertErrorMatch(t, "test error", err)
 
 	want := []execution{


### PR DESCRIPTION
Resolves issue https://github.com/redhat-developer/kam/issues/212

**What type of PR is this?**
/kind bug


**Why we need it**:

The bootstrap command  
```
kam bootstrap --service-repo-url https://github.com/ishitasequeira/taxi --gitops-repo-url https://github.com/ishitasequeira/gitops.git --image-repo quay.io/isequeir/taxi --dockercfgjson isequeir-robot-auth.json --git-host-access-token ******* --output resources --overwrite --push-to-git=true
``` 
when applied to the existing output directory, the folder gets updated but the remote origin does not get updated according to the new repo and the bootstrap command fails with below error.

**What does this PR do**:
In this PR, we fix the above issue. While executing the bootstrap command, we check if the overwrite flag is set  or not set, `--push-to-git=true` and if the `.git` directory exists in the OutputPath. for `push-to-git=true`, if the overwrite flag is not set and the `.git` directory is present, we return an error and If the overwrite flag is set, we remove the existing `.git` directory before performing `git init` in the OutputPath.

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #212 

**How to test changes / Special notes to the reviewer**:

**Pre-Steps:**
1. Execute the initial bootstrap command for the first time
```
kam bootstrap --service-repo-url https://github.com/ishitasequeira/taxi.git --gitops-repo-url https://github.com/<username>/gitops.git  --image-repo quay.io/isequeir/image-repo --dockercfgjson ~/Downloads/<username>-robot-auth.json --git-host-access-token ****  --output ~/go/src/github.com/test/gitops --push-to-git=true
```

2. The above command will succeed successfully as it is executed for the first time.
3. Delete the `pipelines.yaml` and the secrets directory from the OutputPath. 

**Scenario 1:** The .git directory exists in the OutputPath and the overwrite flag is not set with `push-to-git=true`:

4. Delete the repository from GitHub created in above command
5. Execute the same command as above: (without the overwrite flag)
```
kam bootstrap --service-repo-url https://github.com/ishitasequeira/taxi.git --gitops-repo-url https://github.com/<username>/gitops.git  --image-repo quay.io/isequeir/image-repo --dockercfgjson ~/Downloads/<username>-robot-auth.json --git-host-access-token ****  --output ~/go/src/github.com/test/gitops --push-to-git=true
```

The above command will give below error and the bootstrap command will fail as the .git directory is present in the OutputPath. Also, as the above command failed, it does not create the repository.

```
 ✗  .git directory in output path already exists. If you want to replace your existing files, please rerun with --overwrite
```


**Scenario 2:** The .git directory exists in the OutputPath and the overwrite flag is set and `push-to-git=true`:

 6. Execute the below command 
```
kam bootstrap --service-repo-url https://github.com/ishitasequeira/taxi.git --gitops-repo-url https://github.com/<username>/gitops.git  --image-repo quay.io/isequeir/image-repo --dockercfgjson ~/Downloads/<username>-robot-auth.json --git-host-access-token ****  --output ~/go/src/github.com/test/gitops  --overwrite --push-to-git=true
```
The above command should now complete successfully .

 7. To confirm the remote was correctly set, execute ` git remote -v` in the OutputPath
```
$ git remote -v
origin  git@github.com:ishitasequeira/gitops.git (fetch)
origin  git@github.com:ishitasequeira/gitops.git (push)
```

**Scenario 3:** The .git directory exists in the OutputPath and `push-to-git=false`

8. Execute the below command
```
./kam bootstrap --service-repo-url https://github.com/ishitasequeira/taxi.git --gitops-repo-url https://github.com/ishitasequeira/gitops.git  --image-repo quay.io/isequeir/image-repo --dockercfgjson ~/Downloads/isequeir-robot-auth.json --git-host-access-token 5d51786484454160e5418b4d35e4ae257d6487f3  --output ~/go/src/github.com/openshift/redhat-developer/test
```
The above command succeeds even if the OutputPath contains `.git` directory as `push-to-git=false`.



***Interactive mode***

The interactive command fails with below error message if we decide to push to git and the OutputPath contains the `.git` directory.
```
$ ./kam bootstrap
  
Checking dependencies

 ✓  Checking if Sealed Secrets is installed with the default configuration [114ms]
 ✓  Checking if ArgoCD is installed with the default configuration [227ms]
 ✓  Checking if OpenShift Pipelines Operator is installed with the default configuration [263ms]
  
Starting interactive prompt

? Do you want to accept all default values and be prompted only for the minimum required options? no
? You are able to seal secrets. Select Sealed to continue or Unsealed to generate unsealed secrets, which is not recommended. Sealed
? Provide the URL for your GitOps repository https://github.com/ishitasequeira/gitops.git
? Select type of image registry Openshift Internal registry
? Image registry of the form <project>/<app> which is used to push newly built images. test/app
? Provide a secret (minimum 16 characters) that we can use to authenticate incoming hooks from your Git hosting service for repository: https://github.com/ishitasequeira/gitops.git. (if not provided, it will be auto-generated) [? for help] 
? Provide the URL for your Service repository e.g. https://github.com/organisation/service.git https://github.com/ishitasequeira/taxi.git
? Provide a secret (minimum 16 characters) that we can use to authenticate incoming hooks from your Git hosting service for repository: https://github.com/ishitasequeira/taxi.git. (if not provided, it will be auto-generated) [? for help] 
? Please provide a token used to authenticate requests to "https://github.com/ishitasequeira/taxi.git" [? for help] ****************************************
? Do you wish to securely store the git-host-access-token in the keyring on your local machine? no
? Do you want to create and push the resources to your gitops repository? yes
? Add a prefix to the environment names(dev, stage, cicd etc.) to distinguish and identify individual environments? 
? Provide a path to write GitOps resources? /Users/ishitasequeira/go/src/github.com/openshift/redhat-developer/test
 ✗  the .git folder in output path /Users/ishitasequeira/go/src/github.com/openshift/redhat-developer/test already exists. Delete or rename the .git folder and try again
```
