### PR TITLE
KAM on windows uses backslash in paths (844)

### DIFF
--- a/pkg/pipelines/argocd/argocd.go
+++ b/pkg/pipelines/argocd/argocd.go
@@ -104,9 +104,9 @@ type argocdBuilder struct {
 }
 
 func (b *argocdBuilder) Application(env *config.Environment, app *config.Application) error {
-	basePath := filepath.Join(config.PathForArgoCD())
+	basePath := filepath.ToSlash(filepath.Join(filepath.Join(config.PathForArgoCD())))
 	argoFiles := res.Resources{}
-	filename := filepath.Join(basePath, env.Name+"-"+app.Name+"-app.yaml")
+	filename := filepath.ToSlash(filepath.Join(basePath, env.Name+"-"+app.Name+"-app.yaml"))
 
 	argoFiles[filename] = makeApplication(app, env.Name+"-"+app.Name, b.argoNS,
 		defaultProject,
@@ -118,9 +118,9 @@ func (b *argocdBuilder) Application(env *config.Environment, app *config.Applica
 }
 
 func (b *argocdBuilder) Environment(env *config.Environment) error {
-	basePath := filepath.Join(config.PathForArgoCD())
+	basePath := filepath.ToSlash(filepath.Join(filepath.Join(config.PathForArgoCD())))
 	argoFiles := res.Resources{}
-	filename := filepath.Join(basePath, env.Name+"-env-app.yaml")
+	filename := filepath.ToSlash(filepath.Join(basePath, env.Name+"-env-app.yaml"))
 
 	argoFiles[filename] = makeApplication(
 		nil,
@@ -137,16 +137,16 @@ func argoCDConfigResources(cfg *config.Config, repoURL string, files res.Resourc
 	if cfg.ArgoCD.Namespace == "" {
 		return nil
 	}
-	basePath := filepath.Join(config.PathForArgoCD())
-	filename := filepath.Join(basePath, "kustomization.yaml")
-	files[filepath.Join(basePath, "argo-app.yaml")] =
+	basePath := filepath.ToSlash(filepath.Join(config.PathForArgoCD()))
+	filename := filepath.ToSlash(filepath.Join(basePath, "kustomization.yaml"))
+	files[filepath.ToSlash(filepath.Join(basePath, "argo-app.yaml"))] =
 		ignoreDifferences(makeApplication(nil, "argo-app", cfg.ArgoCD.Namespace,
 			defaultProject, cfg.ArgoCD.Namespace, defaultServer,
 			&argoappv1.ApplicationSource{RepoURL: repoURL, Path: basePath}))
 	if cfg.Pipelines != nil {
-		files[filepath.Join(basePath, "cicd-app.yaml")] = ignoreDifferences(
+		files[filepath.ToSlash(filepath.Join(basePath, "cicd-app.yaml"))] = ignoreDifferences(
 			makeApplication(nil, "cicd-app", cfg.ArgoCD.Namespace, defaultProject, cfg.Pipelines.Name, defaultServer,
-				&argoappv1.ApplicationSource{RepoURL: repoURL, Path: filepath.Join(config.PathForPipelines(cfg.Pipelines), "overlays")}))
+				&argoappv1.ApplicationSource{RepoURL: repoURL, Path: filepath.ToSlash(filepath.Join(config.PathForPipelines(cfg.Pipelines), "overlays"))}))
 	}
 	resourceNames := []string{}
 	for k := range files {
@@ -161,7 +161,7 @@ func makeAppSource(env *config.Environment, app *config.Application, repoURL str
 	if app.ConfigRepo == nil {
 		return &argoappv1.ApplicationSource{
 			RepoURL: repoURL,
-			Path:    filepath.Join(config.PathForApplication(env, app), "overlays"),
+			Path:    filepath.ToSlash(filepath.Join(config.PathForApplication(env, app), "overlays")),
 		}
 	}
 	return &argoappv1.ApplicationSource{
@@ -172,8 +172,8 @@ func makeAppSource(env *config.Environment, app *config.Application, repoURL str
 }
 
 func makeEnvSource(env *config.Environment, repoURL string) *argoappv1.ApplicationSource {
-	envPath := filepath.Join(config.PathForEnvironment(env), "env")
-	envBasePath := filepath.Join(envPath, "overlays")
+	envPath := filepath.ToSlash(filepath.Join(config.PathForEnvironment(env), "env"))
+	envBasePath := filepath.ToSlash(filepath.Join(envPath, "overlays"))
 	return &argoappv1.ApplicationSource{
 		RepoURL: repoURL,
 		Path:    envBasePath,

--- a/pkg/pipelines/argocd/argocd_test.go
+++ b/pkg/pipelines/argocd/argocd_test.go
@@ -37,8 +37,8 @@ var (
 		},
 	}
 
-	testEnvPath     = filepath.Join(config.PathForEnvironment(testEnv), "env")
-	testEnvBasePath = filepath.Join(testEnvPath, "overlays")
+	testEnvPath     = filepath.ToSlash(filepath.Join(config.PathForEnvironment(testEnv), "env"))
+	testEnvBasePath = filepath.ToSlash(filepath.Join(testEnvPath, "overlays"))
 )
 
 func TestBuildCreatesArgoCD(t *testing.T) {
@@ -86,7 +86,7 @@ func TestBuildCreatesArgoCD(t *testing.T) {
 			Spec: argoappv1.ApplicationSpec{
 				Source: argoappv1.ApplicationSource{
 					RepoURL: testRepoURL,
-					Path:    filepath.Join(config.PathForApplication(testEnv, testApp), "overlays"),
+					Path:    filepath.ToSlash(filepath.Join(config.PathForApplication(testEnv, testApp), "overlays")),
 				},
 				Destination: argoappv1.ApplicationDestination{
 					Server:    defaultServer,

--- a/pkg/pipelines/bootstrap.go
+++ b/pkg/pipelines/bootstrap.go
@@ -281,12 +281,12 @@ func bootstrapResources(o *BootstrapOptions, appFs afero.Fs) (res.Resources, res
 	if cfg == nil {
 		return nil, nil, errors.New("failed to find a pipeline configuration - unable to continue bootstrap")
 	}
-	secretFilename := filepath.Join("03-secrets", secretName+".yaml")
+	secretFilename := filepath.ToSlash(filepath.Join("03-secrets", secretName+".yaml"))
 	if !o.Insecure {
-		secretsPath := filepath.Join(config.PathForPipelines(cfg), "base", secretFilename)
+		secretsPath := filepath.ToSlash(filepath.Join(config.PathForPipelines(cfg), "base", secretFilename))
 		bootstrapped[secretsPath] = hookSecret
 	} else {
-		secretFilename = filepath.Join("secrets", secretName+".yaml")
+		secretFilename = filepath.ToSlash(filepath.Join("secrets", secretName+".yaml"))
 		otherResources[secretFilename] = opaqueSecret
 	}
 	bindingName, imageRepoBindingFilename, svcImageBinding := createSvcImageBinding(cfg, devEnv, appName, serviceName, imageRepo, !isInternalRegistry)
@@ -624,7 +624,7 @@ func createCICDResources(fs afero.Fs, repo scm.Repository, pipelineConfig *confi
 	outputs[ciPipelinesPath] = pipelines.CreateCIPipeline(meta.NamespacedName(cicdNamespace, "ci-dryrun-from-push-pipeline"), cicdNamespace)
 	outputs[appCiPipelinesPath] = pipelines.CreateAppCIPipeline(meta.NamespacedName(cicdNamespace, "app-ci-pipeline"))
 	pushBinding, pushBindingName := repo.CreatePushBinding(cicdNamespace)
-	outputs[filepath.Join("06-bindings", pushBindingName+".yaml")] = pushBinding
+	outputs[filepath.ToSlash(filepath.Join("06-bindings", pushBindingName+".yaml"))] = pushBinding
 	outputs[pushTemplatePath] = triggers.CreateCIDryRunTemplate(cicdNamespace, saName)
 	outputs[appCIPushTemplatePath] = triggers.CreateDevCIBuildPRTemplate(cicdNamespace, saName)
 	outputs[eventListenerPath] = eventlisteners.Generate(repo, cicdNamespace, saName, eventlisteners.GitOpsWebhookSecret)

--- a/pkg/pipelines/config/config_test.go
+++ b/pkg/pipelines/config/config_test.go
@@ -219,18 +219,18 @@ type testVisitor struct {
 }
 
 func (v *testVisitor) Service(app *Application, env *Environment, svc *Service) error {
-	v.paths = append(v.paths, filepath.Join(env.Name, "apps", app.Name, "services", svc.Name))
-	v.pipelineServices = append(v.pipelineServices, filepath.Join("cicd", env.Name, svc.Name))
+	v.paths = append(v.paths, filepath.ToSlash(filepath.Join(env.Name, "apps", app.Name, "services", svc.Name)))
+	v.pipelineServices = append(v.pipelineServices, filepath.ToSlash(filepath.Join("cicd", env.Name, svc.Name)))
 	return nil
 }
 func (v *testVisitor) Application(env *Environment, app *Application) error {
-	v.paths = append(v.paths, filepath.Join(env.Name, "apps", app.Name))
+	v.paths = append(v.paths, filepath.ToSlash(filepath.Join(env.Name, "apps", app.Name)))
 	return nil
 }
 func (v *testVisitor) Environment(env *Environment) error {
 	if env.Name == "cicd" {
 		v.paths = append(v.paths, v.pipelineServices...)
 	}
-	v.paths = append(v.paths, filepath.Join("envs", env.Name))
+	v.paths = append(v.paths, filepath.ToSlash(filepath.Join("envs", env.Name)))
 	return nil
 }

--- a/pkg/pipelines/config/parser.go
+++ b/pkg/pipelines/config/parser.go
@@ -45,5 +45,5 @@ func ParsePipelinesFolder(fs afero.Fs, folderPath string) (*Manifest, error) {
 	if !info.IsDir() {
 		return nil, fmt.Errorf("the path %q is a file path (required directory path)", folderPath)
 	}
-	return ParseFile(fs, filepath.Join(folderPath, PipelinesFile))
+	return ParseFile(fs, filepath.Join(folderPath, PipelinesFile)) // Don't call filepath.ToSlash
 }

--- a/pkg/pipelines/config/validate.go
+++ b/pkg/pipelines/config/validate.go
@@ -129,7 +129,7 @@ func (vv *validateVisitor) Application(env *Environment, app *Application) error
 
 func (vv *validateVisitor) Service(app *Application, env *Environment, svc *Service) error {
 	svcPath := yamlPath(PathForService(app, env, svc.Name))
-	svcRelativePath := yamlPath(filepath.Join(env.Name, svc.Name))
+	svcRelativePath := yamlPath(filepath.ToSlash(filepath.Join(env.Name, svc.Name)))
 	if svc.SourceURL != "" {
 		previous, ok := vv.serviceURLs[svc.SourceURL]
 		if !ok {

--- a/pkg/pipelines/dryrun/dryrun_test.go
+++ b/pkg/pipelines/dryrun/dryrun_test.go
@@ -90,7 +90,7 @@ func setupGitOpsTree(t *testing.T, fs afero.Fs, base string, withArgoCD bool) {
 
 func executeScript(t *testing.T, fs afero.Fs, baseDir, script string) string {
 	t.Helper()
-	scriptPath := filepath.Join(baseDir, "dryrun_script.sh")
+	scriptPath := filepath.Join(baseDir, "dryrun_script.sh") // Don't call filepath.ToSlash
 	err := afero.WriteFile(fs, scriptPath, []byte(script), 0777)
 	assertNoError(t, err)
 	cmd := exec.Command(scriptPath)

--- a/pkg/pipelines/environment_test.go
+++ b/pkg/pipelines/environment_test.go
@@ -17,7 +17,7 @@ import (
 func TestAddEnv(t *testing.T) {
 	fakeFs := ioutils.NewMemoryFilesystem()
 	gitopsPath := afero.GetTempDir(fakeFs, "test")
-	pipelinesFile := filepath.Join(gitopsPath, pipelinesFile)
+	pipelinesFile := filepath.ToSlash(filepath.Join(gitopsPath, pipelinesFile))
 	envParameters := EnvParameters{
 		PipelinesFolderPath: gitopsPath,
 		EnvName:             "dev",
@@ -36,7 +36,7 @@ func TestAddEnv(t *testing.T) {
 	for _, path := range wantedPaths {
 		t.Run(fmt.Sprintf("checking path %s already exists", path), func(rt *testing.T) {
 			// The inmemory version of Afero doesn't return errors
-			exists, _ := fakeFs.Exists(filepath.Join(gitopsPath, path))
+			exists, _ := fakeFs.Exists(filepath.Join(gitopsPath, path)) // Don't call filepath.ToSlash
 			if !exists {
 				t.Fatalf("The file is not present at path : %v", path)
 			}
@@ -59,7 +59,7 @@ func TestAddEnv(t *testing.T) {
 func TestAddEnvWithClusterProvided(t *testing.T) {
 	fakeFs := ioutils.NewMemoryFilesystem()
 	gitopsPath := afero.GetTempDir(fakeFs, "test")
-	pipelinesFilePath := filepath.Join(gitopsPath, pipelinesFile)
+	pipelinesFilePath := filepath.ToSlash(filepath.Join(gitopsPath, pipelinesFile))
 	envParameters := EnvParameters{
 		PipelinesFolderPath: gitopsPath,
 		EnvName:             "dev",
@@ -79,7 +79,7 @@ func TestAddEnvWithClusterProvided(t *testing.T) {
 	for _, path := range wantedPaths {
 		t.Run(fmt.Sprintf("checking path %s already exists", path), func(rt *testing.T) {
 			// The inmemory version of Afero doesn't return errors
-			exists, _ := fakeFs.Exists(filepath.Join(gitopsPath, path))
+			exists, _ := fakeFs.Exists(filepath.Join(gitopsPath, path)) // Don't call filepath.ToSlash
 			if !exists {
 				t.Fatalf("The file is not present at path : %v", path)
 			}
@@ -106,7 +106,7 @@ func TestAddEnvWithExistingName(t *testing.T) {
 	fakeFs := ioutils.NewMemoryFilesystem()
 	gitopsPath := afero.GetTempDir(fakeFs, "test")
 
-	pipelinesFile := filepath.Join(gitopsPath, pipelinesFile)
+	pipelinesFile := filepath.ToSlash(filepath.Join(gitopsPath, pipelinesFile))
 	envParameters := EnvParameters{
 		PipelinesFolderPath: gitopsPath,
 		EnvName:             "dev",

--- a/pkg/pipelines/imagerepo/imagerepo.go
+++ b/pkg/pipelines/imagerepo/imagerepo.go
@@ -70,8 +70,8 @@ func CreateInternalRegistryResources(cfg *config.PipelinesConfig, sa *corev1.Ser
 	resources := res.Resources{}
 	filenames := []string{}
 
-	filename := filepath.Join("01-namespaces", fmt.Sprintf("%s-environment.yaml", namespace))
-	namespacePath := filepath.Join(config.PathForPipelines(cfg), "base", filename)
+	filename := filepath.ToSlash(filepath.Join("01-namespaces", fmt.Sprintf("%s-environment.yaml", namespace)))
+	namespacePath := filepath.ToSlash(filepath.Join(config.PathForPipelines(cfg), "base", filename))
 	resources[namespacePath] = namespaces.Create(namespace, gitOpsRepoURL)
 	filenames = append(filenames, filename)
 
@@ -81,7 +81,7 @@ func CreateInternalRegistryResources(cfg *config.PipelinesConfig, sa *corev1.Ser
 
 func createInternalRegistryRoleBinding(cfg *config.PipelinesConfig, ns string, sa *corev1.ServiceAccount) (string, res.Resources) {
 	roleBindingName := fmt.Sprintf("internal-registry-%s-binding", ns)
-	roleBindingFilname := filepath.Join("02-rolebindings", fmt.Sprintf("%s.yaml", roleBindingName))
-	roleBindingPath := filepath.Join(config.PathForPipelines(cfg), "base", roleBindingFilname)
+	roleBindingFilname := filepath.ToSlash(filepath.Join("02-rolebindings", fmt.Sprintf("%s.yaml", roleBindingName)))
+	roleBindingPath := filepath.ToSlash(filepath.Join(config.PathForPipelines(cfg), "base", roleBindingFilname))
 	return roleBindingFilname, res.Resources{roleBindingPath: roles.CreateRoleBinding(meta.NamespacedName(ns, roleBindingName), sa, "ClusterRole", "edit")}
 }

--- a/pkg/pipelines/service.go
+++ b/pkg/pipelines/service.go
@@ -51,7 +51,7 @@ func AddService(o *AddServiceOptions, appFs afero.Fs) error {
 	if err != nil {
 		return err
 	}
-	_, err = yaml.WriteResources(appFs, filepath.Join(o.PipelinesFolderPath, ".."), otherResources)
+	_, err = yaml.WriteResources(appFs, filepath.Join(o.PipelinesFolderPath, ".."), otherResources) // Don't call filepath.ToSlash
 	if err != nil {
 		return err
 	}
@@ -61,7 +61,7 @@ func AddService(o *AddServiceOptions, appFs afero.Fs) error {
 	}
 	cfg := m.GetPipelinesConfig()
 	if cfg != nil {
-		base := filepath.Join(o.PipelinesFolderPath, config.PathForPipelines(cfg), "base")
+		base := filepath.ToSlash(filepath.Join(o.PipelinesFolderPath, config.PathForPipelines(cfg), "base"))
 		err = updateKustomization(appFs, base)
 		if err != nil {
 			return err
@@ -114,11 +114,11 @@ func serviceResources(m *config.Manifest, appFs afero.Fs, o *AddServiceOptions) 
 			},
 		}
 		if !o.Insecure {
-			secretFilename := filepath.Join("03-secrets", secretName+".yaml")
-			secretsPath := filepath.Join(config.PathForPipelines(cfg), "base", secretFilename)
+			secretFilename := filepath.ToSlash(filepath.Join("03-secrets", secretName+".yaml"))
+			secretsPath := filepath.ToSlash(filepath.Join(config.PathForPipelines(cfg), "base", secretFilename))
 			files[secretsPath] = hookSecret
 		} else {
-			secretFilename := filepath.Join("secrets", secretName+".yaml")
+			secretFilename := filepath.ToSlash(filepath.Join("secrets", secretName+".yaml"))
 			otherResources[secretFilename] = opaqueSecret
 		}
 
@@ -164,7 +164,7 @@ func serviceResources(m *config.Manifest, appFs afero.Fs, o *AddServiceOptions) 
 		return nil, nil, err
 	}
 
-	files[filepath.Base(filepath.Join(o.PipelinesFolderPath, pipelinesFile))] = m
+	files[filepath.Base(filepath.Join(o.PipelinesFolderPath, pipelinesFile))] = m // Don't call filepath.ToSlash
 	built, err := buildResources(appFs, m)
 	if err != nil {
 		return nil, nil, err
@@ -227,11 +227,11 @@ func makeSvcImageBindingName(envName, appName, svcName string) string {
 }
 
 func makeSvcImageBindingFilename(bindingName string) string {
-	return filepath.Join("06-bindings", bindingName+".yaml")
+	return filepath.ToSlash(filepath.Join("06-bindings", bindingName+".yaml"))
 }
 
 func makeImageBindingPath(cfg *config.PipelinesConfig, imageRepoBindingFilename string) string {
-	return filepath.Join(config.PathForPipelines(cfg), "base", imageRepoBindingFilename)
+	return filepath.ToSlash(filepath.Join(config.PathForPipelines(cfg), "base", imageRepoBindingFilename))
 }
 
 func createSvcImageBinding(cfg *config.PipelinesConfig, env *config.Environment, appName, svcName, imageRepo string, isTLSVerify bool) (string, string, res.Resources) {

--- a/pkg/pipelines/service_test.go
+++ b/pkg/pipelines/service_test.go
@@ -410,7 +410,7 @@ func TestAddServiceFilePaths(t *testing.T) {
 
 	fakeFs := ioutils.NewMemoryFilesystem()
 	outputPath := afero.GetTempDir(fakeFs, "test")
-	pipelinesPath := filepath.Join(outputPath, pipelinesFile)
+	pipelinesPath := filepath.Join(outputPath, pipelinesFile) // Don't call filepath.ToSlash
 	m := buildManifest(true, true)
 	b, err := yaml.Marshal(m)
 	assertNoError(t, err)
@@ -441,7 +441,7 @@ func TestAddServiceFilePaths(t *testing.T) {
 	for _, path := range wantedPaths {
 		t.Run(fmt.Sprintf("checking path %s already exists", path), func(rt *testing.T) {
 			// The inmemory version of Afero doesn't return errors
-			exists, _ := fakeFs.Exists(filepath.Join(outputPath, path))
+			exists, _ := fakeFs.Exists(filepath.Join(outputPath, path)) // Don't call filepath.ToSlash
 			if !exists {
 				t.Fatalf("The file is not present at : %v", path)
 			}
@@ -454,7 +454,7 @@ func TestAddServiceFolderPaths(t *testing.T) {
 
 	fakeFs := ioutils.NewMemoryFilesystem()
 	outputPath := afero.GetTempDir(fakeFs, "test")
-	pipelinesPath := filepath.Join(outputPath, pipelinesFile)
+	pipelinesPath := filepath.Join(outputPath, pipelinesFile) // Don't call filepath.ToSlash
 	m := buildManifest(true, true)
 	b, err := yaml.Marshal(m)
 	assertNoError(t, err)
@@ -475,7 +475,7 @@ func TestAddServiceFolderPaths(t *testing.T) {
 	for _, path := range wantedPaths {
 		t.Run(fmt.Sprintf("checking path %s already exists", path), func(rt *testing.T) {
 			// The inmemory version of Afero doesn't return errors
-			exists, _ := fakeFs.DirExists(filepath.Join(outputPath, path))
+			exists, _ := fakeFs.DirExists(filepath.Join(outputPath, path)) // Don't call filepath.ToSlash
 			if !exists {
 				t.Fatalf("The directory does not exist at path : %v", path)
 			}
@@ -566,7 +566,7 @@ func TestAddServiceWithImageWithNoPipelines(t *testing.T) {
 
 	fakeFs := ioutils.NewMemoryFilesystem()
 	outputPath := afero.GetTempDir(fakeFs, "test")
-	pipelinesPath := filepath.Join(outputPath, pipelinesFile)
+	pipelinesPath := filepath.Join(outputPath, pipelinesFile) // Don't call filepath.ToSlash
 	m := buildManifest(true, true)
 	m.Environments = append(m.Environments, &config.Environment{
 		Name: "staging",
@@ -591,7 +591,7 @@ func TestAddServiceWithImageWithNoPipelines(t *testing.T) {
 	for _, path := range wantedPaths {
 		t.Run(fmt.Sprintf("checking path %s already exists", path), func(rt *testing.T) {
 			// The inmemory version of Afero doesn't return errors
-			exists, _ := fakeFs.DirExists(filepath.Join(outputPath, path))
+			exists, _ := fakeFs.DirExists(filepath.Join(outputPath, path)) // Don't call filepath.ToSlash
 			if !exists {
 				t.Fatalf("The directory does not exist at path : %v", path)
 			}
@@ -604,7 +604,7 @@ func TestAddServiceWithoutImage(t *testing.T) {
 
 	fakeFs := ioutils.NewMemoryFilesystem()
 	outputPath := afero.GetTempDir(fakeFs, "test")
-	pipelinesPath := filepath.Join(outputPath, pipelinesFile)
+	pipelinesPath := filepath.ToSlash(filepath.Join(outputPath, pipelinesFile))
 	m := buildManifest(true, true)
 	m.Environments = append(m.Environments, &config.Environment{
 		Name: "staging",
@@ -630,11 +630,11 @@ func TestAddServiceWithoutImage(t *testing.T) {
 
 	for path, resource := range files {
 		t.Run(fmt.Sprintf("checking path %s already exists", path), func(rt *testing.T) {
-			filePath := filepath.Join(outputPath, path)
+			filePath := filepath.Join(outputPath, path) // Don't call filepath.ToSlash
 			exists, err := fakeFs.Exists(filePath)
 			assertNoError(t, err)
 			if !exists {
-				t.Fatalf("The file does not exist at path : %s", filepath.Join(outputPath, path))
+				t.Fatalf("The file does not exist at path : %s", filepath.Join(outputPath, path)) // Don't call filepath.ToSlash
 			}
 			got, err := fakeFs.ReadFile(filePath)
 			assertNoError(t, err)

--- a/pkg/pipelines/tekton_builder.go
+++ b/pkg/pipelines/tekton_builder.go
@@ -56,7 +56,7 @@ func (tb *tektonBuilder) Service(app *config.Application, env *config.Environmen
 }
 
 func getEventListenerPath(cicdPath string) string {
-	return filepath.Join(cicdPath, "base", eventListenerPath)
+	return filepath.ToSlash(filepath.Join(cicdPath, "base", eventListenerPath))
 }
 
 func createTriggersForCICD(gitOpsRepo string, cfg *config.PipelinesConfig) ([]v1alpha1.EventListenerTrigger, error) {

--- a/pkg/pipelines/tekton_builder_test.go
+++ b/pkg/pipelines/tekton_builder_test.go
@@ -28,7 +28,7 @@ func TestBuildEventListener(t *testing.T) {
 		},
 		GitOpsURL: "http://github.com/org/gitops.git",
 	}
-	cicdPath := filepath.Join("config", "test-cicd")
+	cicdPath := filepath.ToSlash(filepath.Join("config", "test-cicd"))
 	got, err := buildEventListenerResources(testRepoName, m)
 	assertNoError(t, err)
 	want := res.Resources{
@@ -51,7 +51,7 @@ func TestBuildEventListenerWithServiceWithNoURL(t *testing.T) {
 			testEnv(testService(), "dev"),
 		},
 	}
-	cicdPath := filepath.Join("config", "test-cicd")
+	cicdPath := filepath.ToSlash(filepath.Join("config", "test-cicd"))
 	gitOpsRepo := "http://github.com/org/gitops.git"
 	got, err := buildEventListenerResources(gitOpsRepo, m)
 	assertNoError(t, err)

--- a/pkg/pipelines/yaml/resources_test.go
+++ b/pkg/pipelines/yaml/resources_test.go
@@ -34,7 +34,7 @@ func TestWriteResources(t *testing.T) {
 		errMsg string
 	}{
 		{"Path with ~", "~/manifest", ""},
-		{"Path without ~", filepath.Join(path, "manifest/gitops"), ""},
+		{"Path without ~", filepath.ToSlash(filepath.Join(path, "manifest", "gitops")), ""},
 		{"Path without permission", "/", "failed to MkDirAll for /test/myfile.yaml"},
 	}
 
@@ -45,10 +45,10 @@ func TestWriteResources(t *testing.T) {
 				t.Fatalf("error mismatch: got %v, want %v", err, tt.errMsg)
 			}
 			if tt.path[0] == '~' {
-				tt.path = filepath.Join(path, strings.Split(tt.path, "~")[1])
+				tt.path = filepath.ToSlash(filepath.Join(path, strings.Split(tt.path, "~")[1]))
 			}
 			if err == nil {
-				assertResourceExists(t, filepath.Join(tt.path, "test/myfile.yaml"), sampleYAML)
+				assertResourceExists(t, filepath.Join(tt.path, "test", "myfile.yaml"), sampleYAML)
 			}
 		})
 	}


### PR DESCRIPTION
Signed-off-by: Keith Chong <kykchong@redhat.com>

**What type of PR is this?**

/kind bug

**What does this PR do / why we need it**:
Deployment of Argo CD apps failed because of the incorrect paths

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes https://github.com/redhat-developer/kam/issues/209

**How to test changes / Special notes to the reviewer**:
Test on Windows
