### PR TITLE
Improve error message if the git driver flag is not specified (#987)

### DIFF
--- a/pkg/cmd/bootstrap.go
+++ b/pkg/cmd/bootstrap.go
@@ -259,7 +259,7 @@ func setAccessToken(io *BootstrapParameters) error {
 	if io.GitHostAccessToken != "" {
 		err := ui.ValidateAccessToken(io.GitHostAccessToken, io.ServiceRepoURL)
 		if err != nil {
-			return fmt.Errorf("Please enter a valid access token for --save-token-keyring: %v", err)
+			return fmt.Errorf("Access token validation failed: %v", err)
 		}
 	}
 	if io.SaveTokenKeyRing {

--- a/pkg/cmd/ui/validate.go
+++ b/pkg/cmd/ui/validate.go
@@ -96,7 +96,7 @@ func ValidateAccessToken(input interface{}, serviceRepo string) error {
 	if s, ok := input.(string); ok {
 		repo, err := git.NewRepository(serviceRepo, s)
 		if err != nil {
-			return err
+			return fmt.Errorf("%w. %s", err, "Check that the --private-repo-driver option is provided.")
 		}
 		parsedURL, err := url.Parse(serviceRepo)
 		if err != nil {

--- a/pkg/cmd/ui/validate_test.go
+++ b/pkg/cmd/ui/validate_test.go
@@ -76,6 +76,29 @@ func TestAccessToken(t *testing.T) {
 	}
 }
 
+func TestAccessTokenForEnterpriseGitLab(t *testing.T) {
+	mockurl := "https://gitlab.cee.redhat.com/example/test.git"
+	validator := makeAccessTokenCheck(mockurl)
+	cmdTests := []struct {
+		desc     string
+		argument string
+		wantErr  string
+	}{
+		{"Access Token is incorrect",
+			"demo-token",
+			`unable to identify driver from hostname: gitlab.cee.redhat.com. Check that the --private-repo-driver option is provided.`},
+	}
+
+	for _, tt := range cmdTests {
+		t.Run(tt.desc, func(t *testing.T) {
+			err := validator(tt.argument)
+			if err.Error() != tt.wantErr {
+				t.Errorf("got %s, want %s", err, tt.wantErr)
+			}
+		})
+	}
+}
+
 func TestValidateURL(t *testing.T) {
 
 	validator := makeURLValidatorCheck()


### PR DESCRIPTION
Signed-off-by: Keith Chong <kykchong@redhat.com>

**What type of PR is this?**

/kind bug

**What does this PR do / why we need it**:
The error message is saying that the token provided is not correct, even though it is.  The issue is that the token validation failed because the git driver was not provided for an private git repo (eg --private-repo-driver=gitlab).  This only happens in non-interactive mode from the command line.  In interactive mode, if the user is prompted for this value, so it's not a problem there.  The error message is changed to indicate that the token validation failed, instead of incorrectly saying that the token is wrong.  Also, the error message should suggest the correct course of action (to specify the aforementioned flag).  

The necessity to add this flag when an internal git repo is used is not immediately obvious, especially when existing scripts have been created that are based on the 'regular' external github URL, and one just simply changes those URLs to the private URLs.

Before:

✓ Checking if Sealed Secrets is installed with the default configuration [302ms]
✓ Checking if ArgoCD is installed with the default configuration [513ms]
✓ Checking if OpenShift Pipelines Operator is installed with the default configuration [585ms]
✗ Please enter a valid access token for --save-token-keyring: unable to identify driver from hostname: gitlab.cee.redhat.com

After, with suggested fix:
✓ Checking if Sealed Secrets is installed with the default configuration [240ms]
✓ Checking if ArgoCD is installed with the default configuration [572ms]
✓ Checking if OpenShift Pipelines Operator is installed with the default configuration [650ms]
✗ Access token validation failed for --save-token-keyring: unable to identify driver from hostname: gitlab.cee.redhat.com. Check that the --private-repo-driver option is provided.


**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes  987

**How to test changes / Special notes to the reviewer**:
A automated test was added.