### PR TITLE
Use port name instead of number

### DIFF
--- a/pkg/pipelines/eventlisteners/routes.go
+++ b/pkg/pipelines/eventlisteners/routes.go
@@ -16,7 +16,7 @@ var (
 	routeTypeMeta = meta.TypeMeta("Route", "route.openshift.io/v1")
 )
 
-const defaultRoutePort = 8000
+const defaultRoutePortName = "http-listener"
 
 // GenerateRoute generates an OpenShift route for the EventListener.
 //
@@ -47,17 +47,15 @@ func createRoute(ns string) routev1.Route {
 				"el-cicd-event-listener",
 				100,
 			),
-			Port:           createRoutePort(defaultRoutePort),
+			Port:           createRoutePort(defaultRoutePortName),
 			WildcardPolicy: routev1.WildcardPolicyNone,
 		},
 	}
 }
 
-func createRoutePort(port int32) *routev1.RoutePort {
+func createRoutePort(portName string) *routev1.RoutePort {
 	return &routev1.RoutePort{
-		TargetPort: intstr.IntOrString{
-			IntVal: port,
-		},
+		TargetPort: intstr.FromString(portName),
 	}
 }
 

--- a/pkg/pipelines/eventlisteners/routes_test.go
+++ b/pkg/pipelines/eventlisteners/routes_test.go
@@ -19,7 +19,7 @@ func TestGenerateRoute(t *testing.T) {
 			"namespace":         "cicd-environment",
 		},
 		"spec": map[string]interface{}{
-			"port": map[string]interface{}{"targetPort": float64(8000)},
+			"port": map[string]interface{}{"targetPort": defaultRoutePortName},
 			"to": map[string]interface{}{
 				"kind":   "Service",
 				"name":   "el-cicd-event-listener",
@@ -53,9 +53,7 @@ func TestCreateRoute(t *testing.T) {
 				Weight: &weight,
 			},
 			Port: &routev1.RoutePort{
-				TargetPort: intstr.IntOrString{
-					IntVal: 8000,
-				},
+				TargetPort: intstr.FromString(defaultRoutePortName),
 			},
 			WildcardPolicy: routev1.WildcardPolicyNone,
 		},
@@ -68,11 +66,9 @@ func TestCreateRoute(t *testing.T) {
 
 func TestCreateRoutePort(t *testing.T) {
 	validRoutePort := &routev1.RoutePort{
-		TargetPort: intstr.IntOrString{
-			IntVal: 8080,
-		},
+		TargetPort: intstr.FromString(defaultRoutePortName),
 	}
-	routePort := createRoutePort(8080)
+	routePort := createRoutePort(defaultRoutePortName)
 	if diff := cmp.Diff(routePort, validRoutePort); diff != "" {
 		t.Fatalf("createRoutePort() failed:\n%s", diff)
 	}

--- a/pkg/pipelines/routes/routes.go
+++ b/pkg/pipelines/routes/routes.go
@@ -14,7 +14,7 @@ var (
 	routeTypeMeta = meta.TypeMeta("Route", "route.openshift.io/v1")
 )
 
-const defaultRoutePort = 8080
+const defaultRoutePortName = "http"
 
 // NewFromService creates and returns an OpenShift route preconfigured for the
 // provided Service.
@@ -48,15 +48,15 @@ func createRoute(svc *corev1.Service) routev1.Route {
 				svc.Name,
 				100,
 			),
-			Port:           createRoutePort(svc.Spec.Ports[0].Port),
+			Port:           createRoutePort(svc.Spec.Ports[0].Name),
 			WildcardPolicy: routev1.WildcardPolicyNone,
 		},
 	}
 }
 
-func createRoutePort(port int32) *routev1.RoutePort {
+func createRoutePort(portName string) *routev1.RoutePort {
 	return &routev1.RoutePort{
-		TargetPort: intstr.FromInt(int(port)),
+		TargetPort: intstr.FromString(portName),
 	}
 }
 

--- a/pkg/pipelines/routes/routes_test.go
+++ b/pkg/pipelines/routes/routes_test.go
@@ -40,7 +40,7 @@ func TestNewFromService(t *testing.T) {
 			"namespace":         testNS,
 		},
 		"spec": map[string]interface{}{
-			"port": map[string]interface{}{"targetPort": float64(8080)},
+			"port": map[string]interface{}{"targetPort": defaultRoutePortName},
 			"to": map[string]interface{}{
 				"kind":   "Service",
 				"name":   testName,
@@ -74,9 +74,7 @@ func TestCreateRoute(t *testing.T) {
 				Weight: &weight,
 			},
 			Port: &routev1.RoutePort{
-				TargetPort: intstr.IntOrString{
-					IntVal: 8080,
-				},
+				TargetPort: intstr.FromString(defaultRoutePortName),
 			},
 			WildcardPolicy: routev1.WildcardPolicyNone,
 		},
@@ -89,11 +87,9 @@ func TestCreateRoute(t *testing.T) {
 
 func TestCreateRoutePort(t *testing.T) {
 	validRoutePort := &routev1.RoutePort{
-		TargetPort: intstr.IntOrString{
-			IntVal: 8080,
-		},
+		TargetPort: intstr.FromString(defaultRoutePortName),
 	}
-	routePort := createRoutePort(8080)
+	routePort := createRoutePort(defaultRoutePortName)
 	if diff := cmp.Diff(routePort, validRoutePort); diff != "" {
 		t.Fatalf("createRoutePort() failed:\n%s", diff)
 	}


### PR DESCRIPTION
**What type of PR is this?**
> /kind cleanup


**What does this PR do / why we need it**:
Routes generated by Kam should use service port names instead of hardcoded numbers

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**: #243 

Fixes #?

**How to test changes / Special notes to the reviewer**:
1. The route generated for event listener and sample service should refer to port name
2. Day 1 operations should work as expected