### PR TITLE
Fix warning message when pipelines operator is not found

### DIFF
--- a/pkg/cmd/bootstrap.go
+++ b/pkg/cmd/bootstrap.go
@@ -310,7 +310,7 @@ func checkBootstrapDependencies(io *BootstrapParameters, client *utility.Client,
 		}
 	}
 
-	spinner.Start("Checking if ArgoCD is installed with the default configuration", false)
+	spinner.Start("Checking if Argo CD is installed with the default configuration", false)
 	if err := client.CheckIfArgoCDExists(argocd.ArgoCDNamespace); err != nil {
 		warnIfNotFound(spinner, "Please install OpenShift GitOps Operator from OperatorHub", err)
 		if !apierrors.IsNotFound(err) {
@@ -321,7 +321,7 @@ func checkBootstrapDependencies(io *BootstrapParameters, client *utility.Client,
 
 	spinner.Start("Checking if OpenShift Pipelines Operator is installed with the default configuration", false)
 	if err := client.CheckIfPipelinesExists(pipelinesOperatorNS); err != nil {
-		warnIfNotFound(spinner, "Please install OpenShift GitOps Operator from OperatorHub", err)
+		warnIfNotFound(spinner, "Please install OpenShift Pipelines Operator from OperatorHub", err)
 		if !apierrors.IsNotFound(err) {
 			return fmt.Errorf("failed to check for OpenShift Pipelines Operator: %w", err)
 		}

--- a/pkg/cmd/bootstrap_test.go
+++ b/pkg/cmd/bootstrap_test.go
@@ -281,8 +281,8 @@ func TestDependenciesWithNothingInstalled(t *testing.T) {
 
 	wantMsg := `
 Checking if Sealed Secrets is installed with the default configuration [The Sealed Secrets Controller was not detected]
-Checking if ArgoCD is installed with the default configuration [Please install OpenShift GitOps Operator from OperatorHub]
-Checking if OpenShift Pipelines Operator is installed with the default configuration [Please install OpenShift GitOps Operator from OperatorHub]`
+Checking if Argo CD is installed with the default configuration [Please install OpenShift GitOps Operator from OperatorHub]
+Checking if OpenShift Pipelines Operator is installed with the default configuration [Please install OpenShift Pipelines Operator from OperatorHub]`
 
 	buff := &bytes.Buffer{}
 	fakeSpinner := &mockSpinner{writer: buff}
@@ -300,7 +300,7 @@ func TestDependenciesWithAllInstalled(t *testing.T) {
 
 	wantMsg := `
 Checking if Sealed Secrets is installed with the default configuration
-Checking if ArgoCD is installed with the default configuration
+Checking if Argo CD is installed with the default configuration
 Checking if OpenShift Pipelines Operator is installed with the default configuration`
 
 	buff := &bytes.Buffer{}
@@ -322,7 +322,7 @@ func TestDependenciesWithAllInstalledDifferentSealedSecretsService(t *testing.T)
 	// expect negative Sealed Secrets check
 	wantMsg := `
 Checking if Sealed Secrets is installed with the default configuration [The Sealed Secrets Controller was not detected]
-Checking if ArgoCD is installed with the default configuration
+Checking if Argo CD is installed with the default configuration
 Checking if OpenShift Pipelines Operator is installed with the default configuration`
 
 	buff := &bytes.Buffer{}
@@ -342,7 +342,7 @@ func TestDependenciesWithAllInstalledCustomSealedSecretsService(t *testing.T) {
 	// expect checking and finding the custom Sealed Secrets config
 	wantMsg := `
 Checking if Sealed Secrets is installed with custom configuration
-Checking if ArgoCD is installed with the default configuration
+Checking if Argo CD is installed with the default configuration
 Checking if OpenShift Pipelines Operator is installed with the default configuration`
 
 	buff := &bytes.Buffer{}
@@ -365,7 +365,7 @@ func TestDependenciesWithAllInstalledCustomSealedSecretsServiceButDefaultIsInsta
 	// expect checking custom Sealed Secrets, but unsuccessful
 	wantMsg := `
 Checking if Sealed Secrets is installed with custom configuration [Provided Sealed Secrets namespace/name are not valid. Please verify]
-Checking if ArgoCD is installed with the default configuration
+Checking if Argo CD is installed with the default configuration
 Checking if OpenShift Pipelines Operator is installed with the default configuration`
 
 	buff := &bytes.Buffer{}
@@ -388,7 +388,7 @@ func TestDependenciesWithAllInstalledCustomSealedSecretsServiceButNotMatched(t *
 
 	wantMsg := `
 Checking if Sealed Secrets is installed with custom configuration [Provided Sealed Secrets namespace/name are not valid. Please verify]
-Checking if ArgoCD is installed with the default configuration
+Checking if Argo CD is installed with the default configuration
 Checking if OpenShift Pipelines Operator is installed with the default configuration`
 
 	buff := &bytes.Buffer{}
@@ -406,7 +406,7 @@ func TestDependenciesWithNoArgoCD(t *testing.T) {
 
 	wantMsg := `
 Checking if Sealed Secrets is installed with the default configuration
-Checking if ArgoCD is installed with the default configuration [Please install OpenShift GitOps Operator from OperatorHub]
+Checking if Argo CD is installed with the default configuration [Please install OpenShift GitOps Operator from OperatorHub]
 Checking if OpenShift Pipelines Operator is installed with the default configuration`
 
 	buff := &bytes.Buffer{}
@@ -426,8 +426,8 @@ func TestDependenciesWithNoPipelines(t *testing.T) {
 
 	wantMsg := `
 Checking if Sealed Secrets is installed with the default configuration
-Checking if ArgoCD is installed with the default configuration
-Checking if OpenShift Pipelines Operator is installed with the default configuration [Please install OpenShift GitOps Operator from OperatorHub]`
+Checking if Argo CD is installed with the default configuration
+Checking if OpenShift Pipelines Operator is installed with the default configuration [Please install OpenShift Pipelines Operator from OperatorHub]`
 
 	buff := &bytes.Buffer{}
 	fakeSpinner := &mockSpinner{writer: buff}


### PR DESCRIPTION
**What type of PR is this?**
> /kind bug


**What does this PR do / why we need it**:

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:
1. Warning message for pipelines operator not found should ask users to install the Pipelines operator from OperatorHub