### PR TITLE
Create basic auth secret for private repository

### DIFF
--- a/pkg/pipelines/bootstrap_test.go
+++ b/pkg/pipelines/bootstrap_test.go
@@ -44,7 +44,7 @@ func TestBootstrapManifest(t *testing.T) {
 	r, otherResources, err := bootstrapResources(params, ioutils.NewMemoryFilesystem())
 	fatalIfError(t, err)
 
-	otherResourcesNotEmpty := 3
+	otherResourcesNotEmpty := 4
 	if diff := cmp.Diff(otherResourcesNotEmpty, len(otherResources)); diff != "" {
 		t.Fatalf("other resources is empty:\n%s", diff)
 	}
@@ -320,7 +320,7 @@ func TestGenerateSecrets(t *testing.T) {
 		ObjectMeta: meta.ObjectMeta(
 			types.NamespacedName{Name: "test-sa", Namespace: "test-ns"},
 		),
-		Secrets: []corev1.ObjectReference{{Name: authTokenSecretName}},
+		Secrets: []corev1.ObjectReference{{Name: authTokenSecretName}, {Name: basicAuthTokenName}},
 	}
 	if diff := cmp.Diff(wantSA, outputs[serviceAccountPath]); diff != "" {
 		t.Fatalf("generatedSecrets failed to update the ServiceAccount:\n%s", diff)

--- a/pkg/pipelines/secrets/secrets.go
+++ b/pkg/pipelines/secrets/secrets.go
@@ -44,7 +44,7 @@ func CreateUnsealedSecret(name types.NamespacedName, data, secretKey string) (*c
 
 // CreateUnsealedBasicAuthSecret creates a SealedSecret with a BasicAuth type
 // secret.
-func CreateUnsealedBasicAuthSecret(name, service types.NamespacedName, token string,
+func CreateUnsealedBasicAuthSecret(name types.NamespacedName, token string,
 	opts ...meta.ObjectMetaOpt) *corev1.Secret {
 	return createBasicAuthSecret(name, token, opts...)
 }


### PR DESCRIPTION
**What type of PR is this?**

> /kind bug


**What does this PR do / why we need it**:

Tekton expects a secret of type basic-auth to be present in the namespace which will be used for accessing private repositories. This PR adds the missing basic auth secret that was removed by #236 

Ref: https://github.com/tektoncd/pipeline/blob/main/docs/auth.md#understanding-credential-selection


**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes https://issues.redhat.com/browse/GITOPS-1074

**How to test changes / Special notes to the reviewer**:

Day 1 and Day 2 operations with a private repository 