### PR TITLE
Use rhel8/httpd-24 image to serve kam

### DIFF
--- a/Dockerfile.serve
+++ b/Dockerfile.serve
@@ -5,8 +5,7 @@ COPY . .
 RUN make all_platforms 
 
 
-FROM registry.access.redhat.com/rhscl/httpd-24-rhel7
-# Image registry.redhat.io/rhel8/httpd-24 needs authentication
+FROM registry.redhat.io/rhel8/httpd-24
 
 # Add application sources
 RUN mkdir -p /var/www/html/kam


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup


**What does this PR do / why we need it**:
Update the base image from `rhscl/httpd-24-rhel7` to `rhel8-httpd-24`

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #290 

**How to test changes / Special notes to the reviewer**:
1. Build an image for KAM with the updated image
2. KAM container should serve the kam binaries