### PR TITLE
fix: sanitize trigger binding name

### DIFF
--- a/pkg/pipelines/service.go
+++ b/pkg/pipelines/service.go
@@ -207,7 +207,11 @@ func updateKustomization(appFs afero.Fs, base string) error {
 }
 
 func makeSvcImageBindingName(envName, appName, svcName string) string {
-	return fmt.Sprintf("%s-%s-%s-binding", envName, appName, svcName)
+	bindingName := fmt.Sprintf("%s-%s-%s", envName, appName, svcName)
+	if len(bindingName) > 54 {
+		bindingName = bindingName[:54]
+	}
+	return fmt.Sprintf("%s-binding", bindingName)
 }
 
 func makeSvcImageBindingFilename(bindingName string) string {


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind` line, and delete the rest.
> For example, `> /kind bug` would simply become: `/kind bug`

> /kind bug

**What does this PR do / why we need it**:
Sanitize the trigger binding name so it's a valid DNS1035 name


**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:
1. Add an env and a service with long names
2. Create Webhook cmd should suceed

