### PR TITLE
chore: add flags for external linker to satisfy RPMdiff bind-now test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ DARWIN=$(EXECUTABLE)_darwin_amd64
 PKGS := $(shell go list  ./... | grep -v test/e2e | grep -v vendor)
 FMTPKGS := $(shell go list  ./... | grep -v vendor)
 VERSION=$(shell git describe --tags --always --long --dirty)
-LD_FLAGS="-s -w -X github.com/redhat-developer/kam/pkg/cmd/version.Version=$(VERSION)"
+LD_FLAGS='-s -w -X github.com/redhat-developer/kam/pkg/cmd/version.Version=$(VERSION) -extldflags "-Wl,-z,now"'
 
 .PHONY: all_platforms
 all_platforms: windows linux darwin 


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind` line, and delete the rest.
> For example, `> /kind bug` would simply become: `/kind bug`

> /kind bug
> /kind cleanup
> /kind failing-test
> /kind enhancement
> /kind documentation
> /kind code-refactoring


**What does this PR do / why we need it**:
it seems like kam pulls in the `net` package as a dependency which I suspect is causing `cgo` to be used for compilation indirectly and maybe causing kam to be dynamically linked. (This might also be putting the KAM binary in a position to benefit from supplying the `-buildmode=pie` flag) The [RPMDiff test](https://rpmdiff.engineering.redhat.com/run/527677/7/) in cpaas currently throws an error because we don't add the `-Wl,-z,now` flags for external linker while building the kam binary 
This PR fixes that 

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes https://issues.redhat.com/browse/GITOPS-1714 partially

**How to test changes / Special notes to the reviewer**:
