### PR TITLE
Increase the wait timeout to 20 minutes while syncing applications

### DIFF
--- a/test/e2e/kamsuite/kamsuite.go
+++ b/test/e2e/kamsuite/kamsuite.go
@@ -193,7 +193,7 @@ func deleteGithubRepository(repoURL, token string) {
 }
 
 func waitSync(app string, state string) error {
-	err := wait.Poll(time.Second*1, time.Minute*10, func() (bool, error) {
+	err := wait.Poll(time.Second*1, time.Minute*20, func() (bool, error) {
 		return argoAppStatusMatch(state, app)
 	})
 	if err != nil {


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind` line, and delete the rest.
> For example, `> /kind bug` would simply become: `/kind bug`

> /kind bug
> /kind cleanup
> /kind failing-test
> /kind enhancement
> /kind documentation
> /kind code-refactoring


**What does this PR do / why we need it**:

I am trying to add OCP 4.10 and 4.11 into Openshift CI. The jobs seem flaky while rehearsing them and sometimes fail due to timeout. 

https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_release/27689/rehearse-27689-pull-ci-redhat-developer-kam-master-v4.10-integration-e2e/1513752196313780224#1:build-log.txt%3A982

https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_release/27689/rehearse-27689-pull-ci-redhat-developer-kam-master-v4.11-integration-e2e/1513752196724822016#1:build-log.txt%3A927

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:
