### PR TITLE
Create different GitOps repositories for different OCP versions in CI checks

### DIFF
--- a/test/e2e/kamsuite/kamsuite.go
+++ b/test/e2e/kamsuite/kamsuite.go
@@ -145,7 +145,7 @@ func envVariableCheck() bool {
 				return false
 			}
 			os.Setenv("SERVICE_REPO_URL", "https://github.com/kam-bot/taxi")
-			os.Setenv("GITOPS_REPO_URL", "https://github.com/kam-bot/taxi-"+os.Getenv("PRNO")+majorVersion)
+			os.Setenv("GITOPS_REPO_URL", "https://github.com/kam-bot/gitops-"+os.Getenv("PRNO")+majorVersion)
 			os.Setenv("IMAGE_REPO", "quay.io/kam-bot/taxi")
 			os.Setenv("BUS_REPO_URL", "https://github.com/kam-bot/bus")
 			os.Setenv("DOCKERCONFIGJSON_PATH", os.Getenv("KAM_QUAY_DOCKER_CONF_SECRET_FILE"))
@@ -485,7 +485,7 @@ func openhiftServerVersion() (string, error) {
 		return "", err
 	}
 
-	re := regexp.MustCompile(`Server\s+Version:\s+(\d.{2})`)
+	re := regexp.MustCompile(`Server\s+Version:\s+(4.\d+)`)
 	return strings.Replace(strings.Trim(re.FindStringSubmatch(stdout.String())[1], "\""), ".", "", -1), nil
 }
 

--- a/test/e2e/kamsuite/kamsuite.go
+++ b/test/e2e/kamsuite/kamsuite.go
@@ -485,7 +485,7 @@ func openhiftServerVersion() (string, error) {
 		return "", err
 	}
 
-	re := regexp.MustCompile(`Server\s+Version:\s+(4.\d+)`)
+	re := regexp.MustCompile(`Server\s+Version:\s+(\d\.\d\d?)`)
 	return strings.Replace(strings.Trim(re.FindStringSubmatch(stdout.String())[1], "\""), ".", "", -1), nil
 }
 


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind` line, and delete the rest.
> For example, `> /kind bug` would simply become: `/kind bug`

> /kind bug
> /kind cleanup
> /kind failing-test
> /kind enhancement
> /kind documentation
> /kind code-refactoring


**What does this PR do / why we need it**:

Changing the regexp slightly, to be able to create different GitOps repositories for OCP versions 4.10 and 4.11 in CI checks. 

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:
