### PR TITLE
apply --dryrun no longer uses 'true' or 'false'. Instead it uses 'non…

### DIFF
--- a/pkg/pipelines/pipelines/pipelines.go
+++ b/pkg/pipelines/pipelines/pipelines.go
@@ -161,7 +161,7 @@ func createCIPipelineTask(taskName string) pipelinev1.PipelineTask {
 			Inputs: []pipelinev1.PipelineTaskInputResource{createInputTaskResource("source", "source-repo")},
 		},
 		Params: []pipelinev1.Param{
-			createTaskParam("DRYRUN", "true"),
+			createTaskParam("DRYRUN", "server"),
 		},
 		RunAfter: []string{PendingCommitStatusTask},
 	}

--- a/pkg/pipelines/tasks/deploy_from_source_task.go
+++ b/pkg/pipelines/tasks/deploy_from_source_task.go
@@ -39,9 +39,9 @@ func paramsForDeploymentFromSourceTask() []pipelinev1.ParamSpec {
 	return []pipelinev1.ParamSpec{
 		createTaskParamWithDefault(
 			"DRYRUN",
-			"If true run a server-side dryrun.",
+			"If 'server' run a server-side dryrun.",
 			pipelinev1.ParamTypeString,
-			"false",
+			"none",
 		),
 	}
 }


### PR DESCRIPTION
…e', 'client', and 'server'.

**What type of PR is this?**
> Uncomment only one ` /kind` line, and delete the rest.
> For example, `> /kind bug` would simply become: `/kind bug`

> /kind bug
> /kind cleanup
> /kind failing-test
> /kind enhancement
> /kind documentation
> /kind code-refactoring


**What does this PR do / why we need it**:

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:
